### PR TITLE
Configure wheel packaging for project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,15 @@ herbarium-dwc = "cli:app"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["config/config.default.toml"]
+
+[tool.hatch.build.targets.wheel]
+packages = [
+    "dwc",
+    "engines",
+    "io_utils",
+    "qc",
+]
+py-modules = ["cli"]


### PR DESCRIPTION
## Summary
- configure Hatch build to package project modules and CLI
- include default configuration file in wheel

## Testing
- `pytest`
- `uv pip install -e .` *(fails: Failed to fetch: https://pypi.org/simple/hatchling/)*

------
https://chatgpt.com/codex/tasks/task_e_68a78f4a7374832f9b89e6a9d60963b0