### PR TITLE
Add IO utility tests and fix CLI options

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -91,9 +91,21 @@ try:  # optional dependency
 
     @app.command()
     def process(
-        input: Path = typer.Option(..., "--input", "-i", exists=True, file_ok=False, dir_ok=True, help="Directory of images"),
-        output: Path = typer.Option(..., "--output", "-o", file_ok=False, dir_ok=True, help="Output directory"),
-        config: Optional[Path] = typer.Option(None, "--config", "-c", exists=True, dir_ok=False, file_ok=True, help="Optional config file"),
+        input: Path = typer.Option(
+            ..., "--input", "-i", exists=True, file_okay=False, dir_okay=True, help="Directory of images"
+        ),
+        output: Path = typer.Option(
+            ..., "--output", "-o", file_okay=False, dir_okay=True, help="Output directory"
+        ),
+        config: Optional[Path] = typer.Option(
+            None,
+            "--config",
+            "-c",
+            exists=True,
+            dir_okay=False,
+            file_okay=True,
+            help="Optional config file",
+        ),
     ) -> None:
         process_cli(input, output, config)
 

--- a/tests/unit/test_read.py
+++ b/tests/unit/test_read.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from io_utils.read import iter_images, compute_sha256
+
+def test_iter_images_supported_extensions(tmp_path: Path) -> None:
+    # create files with supported and unsupported extensions
+    (tmp_path / "img1.jpg").write_text("a")
+    (tmp_path / "img2.jpeg").write_text("b")
+    (tmp_path / "img3.PNG").write_text("c")
+    (tmp_path / "doc.txt").write_text("d")
+    (tmp_path / "img.gif").write_text("e")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "img4.jpg").write_text("f")
+    (sub / "note.md").write_text("g")
+    images = list(iter_images(tmp_path))
+    expected = sorted([
+        tmp_path / "img1.jpg",
+        tmp_path / "img2.jpeg",
+        tmp_path / "img3.PNG",
+        sub / "img4.jpg",
+    ], key=lambda p: str(p))
+    assert images == expected
+
+def test_compute_sha256_hash(tmp_path: Path) -> None:
+    data = b"hello"
+    file_path = tmp_path / "file.txt"
+    file_path.write_bytes(data)
+    expected = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    assert compute_sha256(file_path) == expected

--- a/tests/unit/test_write.py
+++ b/tests/unit/test_write.py
@@ -1,0 +1,37 @@
+import sys
+import csv
+import json
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from io_utils.write import write_manifest, write_dwc_csv, write_jsonl, DWC_COLUMNS
+
+def test_write_manifest(tmp_path: Path) -> None:
+    meta = {"foo": "bar"}
+    write_manifest(tmp_path, meta)
+    manifest_path = tmp_path / "manifest.json"
+    assert manifest_path.exists()
+    assert json.loads(manifest_path.read_text()) == meta
+
+def test_write_dwc_csv(tmp_path: Path) -> None:
+    rows = [{"catalogNumber": "1", "scientificName": "Test"}]
+    write_dwc_csv(tmp_path, rows)
+    csv_path = tmp_path / "dwc.csv"
+    assert csv_path.exists()
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        data = list(reader)
+        fieldnames = reader.fieldnames
+    assert fieldnames == DWC_COLUMNS
+    assert data[0]["catalogNumber"] == "1"
+    assert data[0]["scientificName"] == "Test"
+    assert data[0]["collectionCode"] == ""
+
+def test_write_jsonl(tmp_path: Path) -> None:
+    events = [{"id": 1}, {"id": 2}]
+    write_jsonl(tmp_path, events)
+    jsonl_path = tmp_path / "raw.jsonl"
+    assert jsonl_path.exists()
+    lines = jsonl_path.read_text().splitlines()
+    assert [json.loads(line) for line in lines] == events


### PR DESCRIPTION
## Summary
- fix Typer option parameter names in CLI
- test image iteration and SHA-256 hashing helpers
- test manifest, CSV, and JSONL writers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79e3f9134832f8c19056c3c4a55f8