### PR TITLE
Add Swift Vision text recognition engine

### DIFF
--- a/engines/vision_swift/Package.swift
+++ b/engines/vision_swift/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "VisionSwift",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .executable(name: "vision_swift", targets: ["VisionSwift"])
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "VisionSwift",
+            dependencies: [],
+            path: "Sources"
+        )
+    ]
+)

--- a/engines/vision_swift/Sources/VisionSwift/main.swift
+++ b/engines/vision_swift/Sources/VisionSwift/main.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Vision
+import ImageIO
+
+struct RecognitionResult: Codable {
+    let text: String
+    let boundingBox: [Double]
+    let confidence: Float
+}
+
+func loadCGImage(from url: URL) -> CGImage? {
+    guard let src = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+    return CGImageSourceCreateImageAtIndex(src, 0, nil)
+}
+
+func recognizeText(in image: CGImage) throws -> [RecognitionResult] {
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = false
+
+    let handler = VNImageRequestHandler(cgImage: image, options: [:])
+    try handler.perform([request])
+
+    guard let observations = request.results as? [VNRecognizedTextObservation] else {
+        return []
+    }
+
+    return observations.compactMap { observation in
+        guard let candidate = observation.topCandidates(1).first else { return nil }
+        let box = observation.boundingBox
+        let boundingBox = [Double(box.origin.x), Double(box.origin.y), Double(box.size.width), Double(box.size.height)]
+        return RecognitionResult(text: candidate.string, boundingBox: boundingBox, confidence: candidate.confidence)
+    }
+}
+
+func main() throws {
+    guard CommandLine.arguments.count > 1 else {
+        throw NSError(domain: "VisionSwift", code: 1, userInfo: [NSLocalizedDescriptionKey: "Image path missing"])
+    }
+
+    let imageURL = URL(fileURLWithPath: CommandLine.arguments[1])
+    guard let image = loadCGImage(from: imageURL) else {
+        throw NSError(domain: "VisionSwift", code: 2, userInfo: [NSLocalizedDescriptionKey: "Unable to load image"])
+    }
+
+    let results = try recognizeText(in: image)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
+    let data = try encoder.encode(results)
+    if let json = String(data: data, encoding: .utf8) {
+        print(json)
+    }
+}
+
+try main()

--- a/engines/vision_swift/__init__.py
+++ b/engines/vision_swift/__init__.py
@@ -1,0 +1,5 @@
+"""Interface to Apple's Vision text recognition via Swift."""
+
+from .run import run
+
+__all__ = ["run"]

--- a/engines/vision_swift/run.py
+++ b/engines/vision_swift/run.py
@@ -1,0 +1,44 @@
+"""Python wrapper for the Swift Vision text recognition engine."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+
+def run(image_path: str) -> Tuple[List[str], List[List[float]], List[float]]:
+    """Run the Swift Vision text recognizer.
+
+    Parameters
+    ----------
+    image_path: str
+        Path to the image file to process.
+
+    Returns
+    -------
+    tuple
+        Three lists: recognized text tokens, bounding boxes, and confidences.
+    """
+
+    pkg_dir = Path(__file__).resolve().parent
+    cmd = [
+        "swift",
+        "run",
+        "--package-path",
+        str(pkg_dir),
+        "vision_swift",
+        image_path,
+    ]
+
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    results = json.loads(proc.stdout)
+
+    tokens = [r["text"] for r in results]
+    boxes = [r["boundingBox"] for r in results]
+    confidences = [r["confidence"] for r in results]
+    return tokens, boxes, confidences
+
+
+__all__ = ["run"]

--- a/tests/unit/test_vision_swift.py
+++ b/tests/unit/test_vision_swift.py
@@ -1,0 +1,27 @@
+import sys
+import json
+import importlib
+from types import SimpleNamespace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engines.vision_swift import run as vision_run
+run_module = importlib.import_module("engines.vision_swift.run")
+
+
+def test_run_parses_output(monkeypatch):
+    fake_output = [
+        {"text": "foo", "boundingBox": [0, 0, 1, 1], "confidence": 0.9},
+        {"text": "bar", "boundingBox": [1, 1, 2, 2], "confidence": 0.8},
+    ]
+
+    def fake_subprocess_run(cmd, capture_output, text, check):
+        return SimpleNamespace(stdout=json.dumps(fake_output))
+
+    monkeypatch.setattr(run_module.subprocess, "run", fake_subprocess_run)
+
+    tokens, boxes, confidences = vision_run("image.png")
+    assert tokens == ["foo", "bar"]
+    assert boxes == [[0, 0, 1, 1], [1, 1, 2, 2]]
+    assert confidences == [0.9, 0.8]


### PR DESCRIPTION
## Summary
- add Swift package using Vision's `VNRecognizeTextRequest`
- expose Python wrapper that runs the Swift binary and returns tokens, bounding boxes, and confidences
- add unit test for the Python wrapper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a29064d0832fa27716dd42f368f7