### PR TITLE
Add Darwin Core schema, normalization, and mapping utilities

### DIFF
--- a/dwc/__init__.py
+++ b/dwc/__init__.py
@@ -1,0 +1,19 @@
+from .schema import DwcRecord, DWC_TERMS
+from .mapper import map_ocr_to_dwc
+from .normalize import normalize_institution, normalize_vocab
+from .validators import (
+    validate,
+    validate_minimal_fields,
+    validate_event_date,
+)
+
+__all__ = [
+    "DwcRecord",
+    "DWC_TERMS",
+    "map_ocr_to_dwc",
+    "normalize_institution",
+    "normalize_vocab",
+    "validate",
+    "validate_minimal_fields",
+    "validate_event_date",
+]

--- a/dwc/mapper.py
+++ b/dwc/mapper.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from .schema import DwcRecord, DWC_TERMS
+from .normalize import normalize_institution, normalize_vocab
+from .validators import validate
+
+
+def map_ocr_to_dwc(ocr_output: Dict[str, Any], minimal_fields: Iterable[str] = ()) -> DwcRecord:
+    """Translate OCR output into a :class:`DwcRecord`.
+
+    Parameters
+    ----------
+    ocr_output: Dict[str, Any]
+        Dictionary containing raw OCR/GPT extracted data.  Keys that match
+        Darwin Core terms are copied into the resulting model.
+    minimal_fields: Iterable[str]
+        Optional list of required Darwin Core terms.  Missing fields are
+        recorded in the ``flags`` attribute of the returned model.
+    """
+
+    data: Dict[str, Any] = {}
+    for term in DWC_TERMS:
+        if term in ocr_output:
+            data[term] = ocr_output.get(term)
+
+    # Normalise institution codes
+    for field in ("institutionCode", "ownerInstitutionCode"):
+        if field in data and data[field]:
+            data[field] = normalize_institution(str(data[field]))
+
+    # Normalise vocabulary-based terms
+    vocab_terms = ["basisOfRecord"]
+    for field in vocab_terms:
+        if field in data and data[field]:
+            data[field] = normalize_vocab(str(data[field]), field)
+
+    record = DwcRecord(**data)
+
+    flags = validate(record, minimal_fields)
+    if flags:
+        existing = record.flags.split(";") if record.flags else []
+        record.flags = ";".join(existing + flags)
+
+    return record

--- a/dwc/normalize.py
+++ b/dwc/normalize.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict
+import tomllib
+
+# Base directory for rule files
+_RULES_DIR = Path(__file__).resolve().parent.parent / "config" / "rules"
+
+
+@lru_cache(maxsize=None)
+def _load_rules(name: str) -> Dict[str, Dict[str, str]]:
+    """Load a TOML rule file from the configuration directory.
+
+    Parameters
+    ----------
+    name: str
+        Name of the rule file without extension.
+    """
+
+    path = _RULES_DIR / f"{name}.toml"
+    if not path.exists():
+        return {}
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def normalize_institution(value: str) -> str:
+    """Return the normalised institution code for ``value``.
+
+    The function consults ``config/rules/institutions.toml`` which is
+    expected to contain a simple mapping of aliases to canonical codes.
+    If no rule matches, the original ``value`` is returned unchanged.
+    """
+
+    if not value:
+        return value
+    rules = _load_rules("institutions")
+    mapping = {k.lower(): v for k, v in rules.items()}
+    return mapping.get(value.lower(), value)
+
+
+def normalize_vocab(value: str, vocab: str) -> str:
+    """Normalise ``value`` based on the vocabulary ``vocab``.
+
+    The ``config/rules/vocab.toml`` file can contain nested tables where the
+    top-level keys correspond to vocabulary names (e.g. ``basisOfRecord``)
+    and the nested key/value pairs map observed values to controlled
+    vocabulary terms.
+    """
+
+    if not value:
+        return value
+    rules = _load_rules("vocab")
+    section = rules.get(vocab, {})
+    mapping = {k.lower(): v for k, v in section.items()}
+    return mapping.get(value.lower(), value)

--- a/dwc/schema.py
+++ b/dwc/schema.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+from pydantic import BaseModel, ConfigDict
+
+# Darwin Core terms supported by this project.  These mirror the
+# column order used when writing CSV output.  Centralising the list here
+# allows other modules to refer to it and keeps the schema and output in
+# sync.
+DWC_TERMS = [
+    "catalogNumber",
+    "collectionCode",
+    "institutionCode",
+    "ownerInstitutionCode",
+    "scientificName",
+    "scientificNameAuthorship",
+    "scientificName_verbatim",
+    "recordedBy",
+    "recordNumber",
+    "eventDate",
+    "verbatimEventDate",
+    "eventDateUncertaintyInDays",
+    "locality",
+    "country",
+    "stateProvince",
+    "municipality",
+    "identifiedBy",
+    "dateIdentified",
+    "identificationRemarks",
+    "basisOfRecord",
+    "datasetName",
+    "occurrenceRemarks",
+    "verbatimLabel",
+    "flags",
+]
+
+
+class DwcRecord(BaseModel):
+    """Pydantic model representing a single Darwin Core record.
+
+    All fields are optional strings.  When serialised via :meth:`to_dict`
+    missing values are converted to empty strings so that CSV output is
+    consistent.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    catalogNumber: Optional[str] = None
+    collectionCode: Optional[str] = None
+    institutionCode: Optional[str] = None
+    ownerInstitutionCode: Optional[str] = None
+    scientificName: Optional[str] = None
+    scientificNameAuthorship: Optional[str] = None
+    scientificName_verbatim: Optional[str] = None
+    recordedBy: Optional[str] = None
+    recordNumber: Optional[str] = None
+    eventDate: Optional[str] = None
+    verbatimEventDate: Optional[str] = None
+    eventDateUncertaintyInDays: Optional[str] = None
+    locality: Optional[str] = None
+    country: Optional[str] = None
+    stateProvince: Optional[str] = None
+    municipality: Optional[str] = None
+    identifiedBy: Optional[str] = None
+    dateIdentified: Optional[str] = None
+    identificationRemarks: Optional[str] = None
+    basisOfRecord: Optional[str] = None
+    datasetName: Optional[str] = None
+    occurrenceRemarks: Optional[str] = None
+    verbatimLabel: Optional[str] = None
+    flags: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, str]:
+        """Return a dictionary representation suitable for CSV writing.
+
+        Any ``None`` values are converted to empty strings and only known
+        Darwin Core terms are returned.
+        """
+
+        return {term: getattr(self, term) or "" for term in DWC_TERMS}

--- a/dwc/validators.py
+++ b/dwc/validators.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+from .schema import DwcRecord
+
+# Simple ISO date pattern YYYY-MM-DD
+ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def validate_minimal_fields(record: DwcRecord, minimal_fields: Iterable[str]) -> List[str]:
+    """Return a list of required fields missing from ``record``."""
+
+    missing = [field for field in minimal_fields if not getattr(record, field, None)]
+    return missing
+
+
+def validate_event_date(value: str | None) -> bool:
+    """Validate that ``value`` conforms to a basic ISO date pattern."""
+
+    if not value:
+        return True
+    return bool(ISO_DATE_RE.match(value))
+
+
+def validate(record: DwcRecord, minimal_fields: Iterable[str] = ()) -> List[str]:
+    """Validate ``record`` returning a list of flag strings.
+
+    Flags are simple text markers describing which checks failed.  The
+    current implementation checks for required fields and validates the
+    ``eventDate`` format.
+    """
+
+    flags: List[str] = []
+    missing = validate_minimal_fields(record, minimal_fields)
+    if missing:
+        flags.append("missing:" + ",".join(missing))
+    if not validate_event_date(record.eventDate):
+        flags.append("invalid:eventDate")
+    return flags

--- a/io_utils/write.py
+++ b/io_utils/write.py
@@ -3,32 +3,8 @@ from typing import Iterable, Dict, Any
 import csv
 import json
 
-DWC_COLUMNS = [
-    "catalogNumber",
-    "collectionCode",
-    "institutionCode",
-    "ownerInstitutionCode",
-    "scientificName",
-    "scientificNameAuthorship",
-    "scientificName_verbatim",
-    "recordedBy",
-    "recordNumber",
-    "eventDate",
-    "verbatimEventDate",
-    "eventDateUncertaintyInDays",
-    "locality",
-    "country",
-    "stateProvince",
-    "municipality",
-    "identifiedBy",
-    "dateIdentified",
-    "identificationRemarks",
-    "basisOfRecord",
-    "datasetName",
-    "occurrenceRemarks",
-    "verbatimLabel",
-    "flags",
-]
+# Use the canonical list of Darwin Core terms defined by the schema module
+from dwc.schema import DWC_TERMS as DWC_COLUMNS
 
 def write_manifest(output_dir: Path, meta: Dict[str, Any]) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add Pydantic model for Darwin Core records and central term list
- implement normalization, validation, and OCR-to-DwC mapping helpers
- reference shared term list when writing Darwin Core CSV output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a2f08298832f9c2e63fd34ae1d54