### PR TITLE
Add GPT extraction modules and dispatch fallback

### DIFF
--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -1,0 +1,20 @@
+from importlib import import_module
+from typing import Any
+
+_TASKS = {
+    "image_to_text": ("engines.gpt", "image_to_text"),
+    "text_to_dwc": ("engines.gpt", "text_to_dwc"),
+}
+
+
+def dispatch(task: str, *args: Any, **kwargs: Any) -> Any:
+    """Dispatch a task to the appropriate engine function."""
+    try:
+        module_name, func_name = _TASKS[task]
+    except KeyError as exc:
+        raise ValueError(f"Unknown task: {task}") from exc
+    module = import_module(module_name)
+    func = getattr(module, func_name)
+    return func(*args, **kwargs)
+
+__all__ = ["dispatch"]

--- a/engines/gpt/__init__.py
+++ b/engines/gpt/__init__.py
@@ -1,0 +1,4 @@
+from .image_to_text import image_to_text
+from .text_to_dwc import text_to_dwc
+
+__all__ = ["image_to_text", "text_to_dwc"]

--- a/engines/gpt/image_to_text.py
+++ b/engines/gpt/image_to_text.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import base64
+from importlib import resources
+from pathlib import Path
+from typing import Dict, Tuple
+
+try:  # optional dependency
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover
+    OpenAI = None
+
+
+def _load_prompt(name: str) -> str:
+    return resources.files(__package__).joinpath("prompts", name).read_text(encoding="utf-8")
+
+
+def image_to_text(image: Path, *, model: str, dry_run: bool = False) -> Tuple[str, Dict[str, float]]:
+    """Use a GPT model to extract text from an image.
+
+    Parameters
+    ----------
+    image:
+        Path to the image on disk.
+    model:
+        The GPT model name to use.
+    dry_run:
+        When ``True`` or when the OpenAI SDK is unavailable, no network
+        call is performed and an empty result is returned.
+    """
+    prompt = _load_prompt("image_to_text.prompt")
+    if dry_run or OpenAI is None:
+        return "", {"text": 0.0}
+
+    client = OpenAI()
+    with image.open("rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+
+    # The exact request structure may vary across OpenAI SDK versions.
+    # This implementation targets the Responses API available in the
+    # official SDK.  If the API changes, the call below should be
+    # updated accordingly.
+    resp = client.responses.create(
+        model=model,
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image", "image": {"b64": b64}},
+                ],
+            }
+        ],
+    )
+
+    text = getattr(resp, "output_text", "")
+    confidence = float(getattr(resp, "confidence", 1.0))
+    return text, {"text": confidence}

--- a/engines/gpt/prompts/image_to_text.prompt
+++ b/engines/gpt/prompts/image_to_text.prompt
@@ -1,0 +1,1 @@
+You are a helpful assistant that extracts text from herbarium specimen images.

--- a/engines/gpt/prompts/text_to_dwc.prompt
+++ b/engines/gpt/prompts/text_to_dwc.prompt
@@ -1,0 +1,2 @@
+You are a helpful assistant that converts text into Darwin Core fields.
+Return JSON with each field having a value and confidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,4 @@ py-modules = ["cli"]
 
 [tool.hatch.build.targets.wheel.package-data]
 config = ["config.default.toml", "rules/*.toml"]
+engines = ["gpt/prompts/*"]


### PR DESCRIPTION
## Summary
- implement GPT image-to-text and text-to-Darwin-Core modules loading prompts and returning confidences
- add engines.dispatch to route tasks
- hook process_cli to GPT fallback and package prompt data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a2c30df4832f96bd20ae81ff1f98