### PR TITLE
Add Vision Swift OCR engine and dispatch support

### DIFF
--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -2,17 +2,22 @@ from importlib import import_module
 from typing import Any
 
 _TASKS = {
-    "image_to_text": ("engines.gpt", "image_to_text"),
-    "text_to_dwc": ("engines.gpt", "text_to_dwc"),
+    "image_to_text": {
+        "gpt": ("engines.gpt", "image_to_text"),
+        "vision": ("engines.vision_swift", "image_to_text"),
+    },
+    "text_to_dwc": {
+        "gpt": ("engines.gpt", "text_to_dwc"),
+    },
 }
 
 
-def dispatch(task: str, *args: Any, **kwargs: Any) -> Any:
+def dispatch(task: str, *args: Any, engine: str = "gpt", **kwargs: Any) -> Any:
     """Dispatch a task to the appropriate engine function."""
     try:
-        module_name, func_name = _TASKS[task]
+        module_name, func_name = _TASKS[task][engine]
     except KeyError as exc:
-        raise ValueError(f"Unknown task: {task}") from exc
+        raise ValueError(f"Unknown task or engine: {task}/{engine}") from exc
     module = import_module(module_name)
     func = getattr(module, func_name)
     return func(*args, **kwargs)

--- a/engines/vision_swift/__init__.py
+++ b/engines/vision_swift/__init__.py
@@ -1,5 +1,31 @@
 """Interface to Apple's Vision text recognition via Swift."""
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
 from .run import run
 
-__all__ = ["run"]
+
+def image_to_text(image: Path) -> Tuple[str, List[float]]:
+    """Extract text from an image using Apple's Vision framework.
+
+    Parameters
+    ----------
+    image:
+        Path to the image file.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the concatenated text and a list of token
+        confidences.
+    """
+
+    tokens, _boxes, confidences = run(str(image))
+    text = " ".join(tokens)
+    return text, confidences
+
+
+__all__ = ["image_to_text", "run"]

--- a/tests/unit/test_vision_swift.py
+++ b/tests/unit/test_vision_swift.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from cli import load_config
+from engines import dispatch
+import engines.vision_swift as vision_swift
 from engines.vision_swift import run as vision_run
 run_module = importlib.import_module("engines.vision_swift.run")
 
@@ -25,3 +28,31 @@ def test_run_parses_output(monkeypatch):
     assert tokens == ["foo", "bar"]
     assert boxes == [[0, 0, 1, 1], [1, 1, 2, 2]]
     assert confidences == [0.9, 0.8]
+
+
+def test_image_to_text_concatenates_tokens(monkeypatch):
+    def fake_run(image_path: str):
+        return ["hello", "world"], [], [0.5, 0.7]
+
+    monkeypatch.setattr(vision_swift, "run", fake_run)
+    text, confidences = vision_swift.image_to_text(Path("image.png"))
+    assert text == "hello world"
+    assert confidences == [0.5, 0.7]
+
+
+def test_dispatch_uses_vision_engine(monkeypatch):
+    cfg = load_config(None)
+    called = {}
+
+    def fake_image_to_text(image: Path):
+        called["used"] = True
+        return "hi", [0.9]
+
+    monkeypatch.setattr(vision_swift, "image_to_text", fake_image_to_text)
+    text, confidences = dispatch(
+        "image_to_text", image=Path("img.png"), engine=cfg["ocr"]["preferred_engine"]
+    )
+
+    assert called["used"] is True
+    assert text == "hi"
+    assert confidences == [0.9]


### PR DESCRIPTION
## Summary
- add Vision Swift `image_to_text` helper that joins recognized tokens
- extend engine dispatcher with configurable `vision` backend
- test Vision Swift token concatenation and dispatch selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3915800832f958a8b7b48db038f