### PR TITLE
Add Tesseract OCR engine

### DIFF
--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -5,6 +5,7 @@ _TASKS = {
     "image_to_text": {
         "gpt": ("engines.gpt", "image_to_text"),
         "vision": ("engines.vision_swift", "image_to_text"),
+        "tesseract": ("engines.tesseract", "image_to_text"),
     },
     "text_to_dwc": {
         "gpt": ("engines.gpt", "text_to_dwc"),

--- a/engines/tesseract/__init__.py
+++ b/engines/tesseract/__init__.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+
+def image_to_text(image: Path, oem: int, psm: int, langs: List[str], extra_args: List[str]) -> Tuple[str, float]:
+    """Run Tesseract OCR on an image and return text and average confidence.
+
+    Parameters
+    ----------
+    image: Path
+        Path to the image file to OCR.
+    oem: int
+        OCR Engine Mode passed to Tesseract (``--oem``).
+    psm: int
+        Page Segmentation Mode passed to Tesseract (``--psm``).
+    langs: list[str]
+        Languages to use, joined with ``+`` for Tesseract's ``lang`` argument.
+    extra_args: list[str]
+        Additional command-line arguments passed to Tesseract.
+    """
+    import pytesseract
+    from pytesseract import Output
+
+    config_parts = [f"--oem {oem}", f"--psm {psm}"]
+    if extra_args:
+        config_parts.extend(extra_args)
+    config = " ".join(config_parts)
+    lang = "+".join(langs)
+
+    data = pytesseract.image_to_data(
+        str(image), lang=lang, config=config, output_type=Output.DICT
+    )
+    tokens = [t for t in data.get("text", []) if t.strip()]
+    confidences = [
+        float(c) for t, c in zip(data.get("text", []), data.get("conf", [])) if t.strip() and str(c) != "-1"
+    ]
+    text = " ".join(tokens)
+    avg_conf = sum(confidences) / len(confidences) / 100 if confidences else 0.0
+    return text, avg_conf
+
+
+__all__ = ["image_to_text"]

--- a/tests/unit/test_tesseract.py
+++ b/tests/unit/test_tesseract.py
@@ -1,0 +1,95 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from cli import load_config
+from engines import dispatch
+
+
+
+def test_load_config_tesseract_overrides(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        """
+[ocr]
+preferred_engine = "tesseract"
+[tesseract]
+oem = 2
+psm = 7
+langs = ["eng","spa"]
+extra_args = ["--foo","bar"]
+"""
+    )
+    cfg = load_config(cfg_path)
+    t_cfg = cfg["tesseract"]
+    assert cfg["ocr"]["preferred_engine"] == "tesseract"
+    assert t_cfg["oem"] == 2
+    assert t_cfg["psm"] == 7
+    assert t_cfg["langs"] == ["eng", "spa"]
+    assert t_cfg["extra_args"] == ["--foo", "bar"]
+
+
+def test_image_to_text_parses_output(monkeypatch, tmp_path: Path) -> None:
+    fake_module = types.SimpleNamespace()
+
+    def fake_image_to_data(image, lang, config, output_type):
+        assert lang == "eng+spa"
+        assert config == "--oem 2 --psm 7 --foo bar"
+        return {
+            "text": ["hello", "", "world"],
+            "conf": ["90", "-1", "80"],
+        }
+
+    fake_module.image_to_data = fake_image_to_data
+    fake_module.Output = types.SimpleNamespace(DICT="dict")
+    monkeypatch.setitem(sys.modules, "pytesseract", fake_module)
+
+    from engines.tesseract import image_to_text
+
+    text, conf = image_to_text(tmp_path / "img.png", 2, 7, ["eng", "spa"], ["--foo", "bar"])
+    assert text == "hello world"
+    assert conf == (90 + 80) / 2 / 100
+
+
+def test_dispatch_uses_tesseract_engine(monkeypatch, tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        """
+[ocr]
+preferred_engine = "tesseract"
+[tesseract]
+oem = 2
+psm = 7
+langs = ["eng","spa"]
+extra_args = ["--foo","bar"]
+"""
+    )
+    cfg = load_config(cfg_path)
+
+    import engines.tesseract as tesseract
+
+    called = {}
+
+    def fake_image_to_text(image, oem, psm, langs, extra_args):
+        called["args"] = (image, oem, psm, langs, extra_args)
+        return "hi", 0.9
+
+    monkeypatch.setattr(tesseract, "image_to_text", fake_image_to_text)
+
+    text, conf = dispatch(
+        "image_to_text",
+        image=Path("img.png"),
+        engine=cfg["ocr"]["preferred_engine"],
+        oem=cfg["tesseract"]["oem"],
+        psm=cfg["tesseract"]["psm"],
+        langs=cfg["tesseract"]["langs"],
+        extra_args=cfg["tesseract"]["extra_args"],
+    )
+
+    assert called["args"] == (
+        Path("img.png"), 2, 7, ["eng", "spa"], ["--foo", "bar"]
+    )
+    assert text == "hi"
+    assert conf == 0.9


### PR DESCRIPTION
## Summary
- implement Tesseract `image_to_text` wrapper returning text and average confidence
- wire Tesseract into engine dispatcher
- add tests for Tesseract config overrides and dispatch

## Testing
- `PYTHONPATH=. pytest -q` *(fails: test_deskew_rotated_image)*

------
https://chatgpt.com/codex/tasks/task_e_68ab97e96718832f8b4d9bc0e625f91b