### PR TITLE
Configure pytest to find CLI module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ engines = ["gpt/prompts/*"]
 dev = [
     "pytest>=8.4.1",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
## Summary
- ensure pytest includes repository root on Python path so `cli` imports work

## Testing
- `pytest tests/unit/test_cli_ocr.py tests/unit/test_cli_preprocess.py`


------
https://chatgpt.com/codex/tasks/task_e_68af7685aa2c832fb107b5d4dce0f4df