### PR TITLE
Add pluggable engine registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,24 @@ pytest -q
 Additional OCR engines (Apple Vision, Tesseract, GPT), quality-control checks,
 and Darwin Core mapping logic will be implemented as the project evolves.
 
+## Engine plugins
+
+OCR and transformation engines are discovered at runtime.  Each engine module
+registers the tasks it implements using:
+
+```python
+from engines import register_task
+register_task("image_to_text", "my_engine", __name__, "image_to_text")
+```
+
+Third-party packages can expose engines via Python entry points in their
+`pyproject.toml`:
+
+```toml
+[project.entry-points."herbarium.engines"]
+my_engine = "my_package.my_module"
+```
+
+The referenced module should call :func:`register_task` during import.
+
 

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -1,3 +1,8 @@
+# Engines register themselves via the ``herbarium.engines`` entry-point group.
+# Third-party packages can expose engines with:
+# [project.entry-points."herbarium.engines"]
+# name = "pkg.module"
+# ``preferred_engine`` must correspond to a registered engine name.
 [ocr]
 preferred_engine = "vision"
 allow_tesseract_on_macos = true

--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -1,26 +1,79 @@
-from importlib import import_module
-from typing import Any
+"""Engine registration and dispatch helpers.
 
-_TASKS = {
-    "image_to_text": {
-        "gpt": ("engines.gpt", "image_to_text"),
-        "vision": ("engines.vision_swift", "image_to_text"),
-        "tesseract": ("engines.tesseract", "image_to_text"),
-    },
-    "text_to_dwc": {
-        "gpt": ("engines.gpt", "text_to_dwc"),
-    },
-}
+This module exposes a small plugin system that allows OCR/DWC engines to
+register the tasks that they implement.  Built-in engines register themselves
+when imported, and additional engines can be discovered via the
+``herbarium.engines`` entry-point group.
+"""
+
+from importlib import import_module, metadata
+from typing import Any, Dict, Tuple
+
+# Registry mapping task -> engine -> (module, function)
+_REGISTRY: Dict[str, Dict[str, Tuple[str, str]]] = {}
+
+
+def register_task(task: str, engine: str, module: str, func: str) -> None:
+    """Register ``func`` from ``module`` as the implementation of a task.
+
+    Parameters
+    ----------
+    task:
+        Name of the task (e.g., ``"image_to_text"``).
+    engine:
+        Engine identifier (e.g., ``"gpt"`` or ``"tesseract"``).
+    module:
+        Import path of the module containing the function.
+    func:
+        Name of the function implementing the task.
+    """
+
+    _REGISTRY.setdefault(task, {})[engine] = (module, func)
+
+
+def _discover_entry_points() -> None:
+    """Load engines exposed via the ``herbarium.engines`` entry point."""
+
+    try:  # Python 3.10+
+        eps = metadata.entry_points().select(group="herbarium.engines")
+    except AttributeError:  # pragma: no cover - older Python
+        eps = metadata.entry_points().get("herbarium.engines", [])
+    for ep in eps:
+        ep.load()  # Importing registers the engine
+
+
+# Import built-in engines so they register themselves on module import.
+for _mod in ("gpt", "vision_swift", "tesseract"):
+    try:
+        import_module(f"{__name__}.{_mod}")
+    except Exception:  # pragma: no cover - optional deps may be missing
+        pass
+
+_discover_entry_points()
 
 
 def dispatch(task: str, *args: Any, engine: str = "gpt", **kwargs: Any) -> Any:
-    """Dispatch a task to the appropriate engine function."""
-    try:
-        module_name, func_name = _TASKS[task][engine]
-    except KeyError as exc:
-        raise ValueError(f"Unknown task or engine: {task}/{engine}") from exc
+    """Dispatch a task to the requested engine.
+
+    Raises
+    ------
+    ValueError
+        If the task or engine is unknown.
+    """
+
+    if task not in _REGISTRY:
+        raise ValueError(f"Unknown task: {task}")
+    engines = _REGISTRY[task]
+    if engine not in engines:
+        available = ", ".join(sorted(engines))
+        raise ValueError(
+            f"Engine '{engine}' unavailable for task '{task}'. Available: {available}"
+        )
+    module_name, func_name = engines[engine]
     module = import_module(module_name)
     func = getattr(module, func_name)
     return func(*args, **kwargs)
 
-__all__ = ["dispatch"]
+
+__all__ = ["dispatch", "register_task"]
+

--- a/engines/gpt/__init__.py
+++ b/engines/gpt/__init__.py
@@ -1,4 +1,9 @@
 from .image_to_text import image_to_text
 from .text_to_dwc import text_to_dwc
 
+from .. import register_task
+
+register_task("image_to_text", "gpt", __name__, "image_to_text")
+register_task("text_to_dwc", "gpt", __name__, "text_to_dwc")
+
 __all__ = ["image_to_text", "text_to_dwc"]

--- a/engines/tesseract/__init__.py
+++ b/engines/tesseract/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Tuple
 
+from .. import register_task
+
 
 def image_to_text(image: Path, oem: int, psm: int, langs: List[str], extra_args: List[str]) -> Tuple[str, float]:
     """Run Tesseract OCR on an image and return text and average confidence.
@@ -40,5 +42,6 @@ def image_to_text(image: Path, oem: int, psm: int, langs: List[str], extra_args:
     avg_conf = sum(confidences) / len(confidences) / 100 if confidences else 0.0
     return text, avg_conf
 
+register_task("image_to_text", "tesseract", __name__, "image_to_text")
 
 __all__ = ["image_to_text"]

--- a/engines/vision_swift/__init__.py
+++ b/engines/vision_swift/__init__.py
@@ -7,6 +7,8 @@ from typing import List, Tuple
 
 from .run import run
 
+from .. import register_task
+
 
 def image_to_text(image: Path) -> Tuple[str, List[float]]:
     """Extract text from an image using Apple's Vision framework.
@@ -27,5 +29,7 @@ def image_to_text(image: Path) -> Tuple[str, List[float]]:
     text = " ".join(tokens)
     return text, confidences
 
+
+register_task("image_to_text", "vision", __name__, "image_to_text")
 
 __all__ = ["image_to_text", "run"]


### PR DESCRIPTION
## Summary
- Introduce `register_task` API and dynamic engine registry with entry-point discovery
- Engines self-register and dispatcher reports unavailable engines clearly
- Document plugin registration and entry-point format in README and config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7ee33a94832fa53ecbac72d54b50