### PR TITLE
Support engine registry validation and pluggable fallback

### DIFF
--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -5,6 +5,10 @@
 # ``preferred_engine`` must correspond to a registered engine name.
 [ocr]
 preferred_engine = "vision"
+# Engines can be limited via ``enabled_engines``.
+# Example for running with only Vision installed:
+# enabled_engines = ["vision"]
+enabled_engines = ["vision", "tesseract", "gpt"]
 allow_tesseract_on_macos = true
 allow_gpt = true
 confidence_threshold = 0.70

--- a/config/config.tesseract-only.toml
+++ b/config/config.tesseract-only.toml
@@ -1,0 +1,18 @@
+# Example configuration using only the Tesseract OCR engine
+
+[ocr]
+preferred_engine = "tesseract"
+enabled_engines = ["tesseract"]
+allow_gpt = false
+allow_tesseract_on_macos = true
+confidence_threshold = 0.70
+
+[gpt]
+dry_run = true
+model = "gpt-4.1-mini"
+
+[tesseract]
+oem = 1
+psm = 6
+langs = ["eng","fra","lat"]
+extra_args = []

--- a/tests/unit/test_cli_preprocess.py
+++ b/tests/unit/test_cli_preprocess.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from PIL import Image
 
 import cli
+import engines
 
 
 def _fake_dispatch(op, **kwargs):
@@ -29,6 +30,7 @@ def test_process_cli_invokes_preprocess_when_enabled(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli, "preprocess_image", fake_preprocess)
     monkeypatch.setattr(cli, "dispatch", _fake_dispatch)
+    monkeypatch.setattr(engines, "dispatch", _fake_dispatch)
 
     cli.process_cli(tmp_path, out_dir, cfg_file)
     assert called["n"] == 1
@@ -55,6 +57,7 @@ def test_process_cli_skips_preprocess_when_disabled(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli, "preprocess_image", fake_preprocess)
     monkeypatch.setattr(cli, "dispatch", _fake_dispatch)
+    monkeypatch.setattr(engines, "dispatch", _fake_dispatch)
 
     cli.process_cli(tmp_path, out_dir, cfg_file)
     assert called["n"] == 0


### PR DESCRIPTION
## Summary
- detect and validate available OCR engines via registry
- allow selecting enabled engines via config or CLI flag
- refactor GPT fallback into pluggable fallback policy
- document single-engine setups in sample configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af81bf7e3c832f9a82ab021e731851