### PR TITLE
feat: configurable preprocessing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ The repository ships optional plugins for Apple Vision, Tesseract, and GPT
 engines. Quality-control checks and full Darwin Core mapping logic will be
 implemented as the project evolves.
 
+## Preprocessing pipeline
+
+Images can be passed through an ordered preprocessing pipeline before OCR.
+Steps are referenced by name and resolved via a simple registry. Configure the
+pipeline and step options in the `[preprocess]` section of the TOML file:
+
+```toml
+[preprocess]
+pipeline = ["grayscale", "deskew", "binarize", "resize"]
+max_dim_px = 4000  # used by the "resize" step
+```
+
+Built-in steps register themselves when `preprocess` is imported, and external
+modules may register additional steps with
+`preprocess.register_preprocessor(name, func)`.
+
 ## Engine plugins
 
 Built-in plugins for Apple Vision (`vision`), Tesseract (`tesseract`), and GPT

--- a/cli.py
+++ b/cli.py
@@ -81,10 +81,8 @@ def process_cli(
             "errors": [],
         }
         pre_cfg = cfg.get("preprocess", {})
-        if any(pre_cfg.get(k) for k in ["grayscale", "deskew", "binarize", "max_dim_px"]):
-            proc_path = preprocess_image(img_path, pre_cfg)
-        else:
-            proc_path = img_path
+        pipeline = pre_cfg.get("pipeline", [])
+        proc_path = preprocess_image(img_path, pre_cfg) if pipeline else img_path
         ocr_cfg = cfg.get("ocr", {})
         available = available_engines("image_to_text")
         enabled = ocr_cfg.get("enabled_engines")

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -25,8 +25,7 @@ langs = ["eng","fra","lat"]
 extra_args = []
 
 [preprocess]
-grayscale = true
-deskew = true
+pipeline = ["grayscale", "deskew", "binarize", "resize"]
 binarize = "adaptive_sauvola"
 max_dim_px = 4000
 

--- a/tests/unit/test_cli_preprocess.py
+++ b/tests/unit/test_cli_preprocess.py
@@ -20,7 +20,7 @@ def test_process_cli_invokes_preprocess_when_enabled(monkeypatch, tmp_path):
     out_dir.mkdir()
 
     cfg_file = tmp_path / "cfg.toml"
-    cfg_file.write_text("[preprocess]\ngrayscale=true\n")
+    cfg_file.write_text("[preprocess]\npipeline=[\"grayscale\"]\n")
 
     called = {"n": 0}
 
@@ -43,11 +43,7 @@ def test_process_cli_skips_preprocess_when_disabled(monkeypatch, tmp_path):
     out_dir.mkdir()
 
     cfg_file = tmp_path / "cfg.toml"
-    cfg_file.write_text("""[preprocess]\n"""
-                        "grayscale=false\n"
-                        "deskew=false\n"
-                        "binarize=false\n"
-                        "max_dim_px=0\n")
+    cfg_file.write_text("[preprocess]\npipeline=[]\n")
 
     called = {"n": 0}
 


### PR DESCRIPTION
## Summary
- add simple registry for preprocessing steps and register built-in steps
- load preprocessing pipeline from config and iterate dynamically
- document pipeline configuration and usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b09e8620a0832facf4069e8a7eca08