### PR TITLE
Expand DWC schema and add identification history writer

### DIFF
--- a/dwc/schema.py
+++ b/dwc/schema.py
@@ -3,33 +3,58 @@ from __future__ import annotations
 from typing import Dict, Optional
 from pydantic import BaseModel, ConfigDict
 
-# Darwin Core terms supported by this project.  These mirror the
-# column order used when writing CSV output.  Centralising the list here
-# allows other modules to refer to it and keeps the schema and output in
-# sync.
+# Darwin Core terms supported by this project. These mirror the column order
+# used when writing CSV output. The list is based on the AAFC-SRDC example
+# dataset and extended with a few project-specific fields at the end.
 DWC_TERMS = [
+    "occurrenceID",
     "catalogNumber",
-    "collectionCode",
+    "otherCatalogNumbers",
     "institutionCode",
+    "collectionCode",
     "ownerInstitutionCode",
-    "scientificName",
-    "scientificNameAuthorship",
-    "scientificName_verbatim",
+    "basisOfRecord",
+    "preparations",
+    "hasFragmentPacket",
+    "disposition",
     "recordedBy",
+    "recordedByID",
     "recordNumber",
     "eventDate",
-    "verbatimEventDate",
-    "eventDateUncertaintyInDays",
-    "locality",
+    "eventTime",
     "country",
     "stateProvince",
+    "county",
     "municipality",
+    "locality",
+    "verbatimLocality",
+    "decimalLatitude",
+    "decimalLongitude",
+    "geodeticDatum",
+    "coordinateUncertaintyInMeters",
+    "habitat",
+    "eventRemarks",
+    "scientificName",
+    "scientificNameAuthorship",
+    "taxonRank",
+    "family",
+    "genus",
+    "specificEpithet",
+    "infraspecificEpithet",
+    "identificationQualifier",
     "identifiedBy",
     "dateIdentified",
     "identificationRemarks",
-    "basisOfRecord",
-    "datasetName",
+    "identificationReferences",
+    "identificationVerificationStatus",
+    "associatedOccurrences",
     "occurrenceRemarks",
+    "dynamicProperties",
+    # Project-specific extensions
+    "scientificName_verbatim",
+    "verbatimEventDate",
+    "eventDateUncertaintyInDays",
+    "datasetName",
     "verbatimLabel",
     "flags",
 ]
@@ -45,28 +70,53 @@ class DwcRecord(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
+    occurrenceID: Optional[str] = None
     catalogNumber: Optional[str] = None
-    collectionCode: Optional[str] = None
+    otherCatalogNumbers: Optional[str] = None
     institutionCode: Optional[str] = None
+    collectionCode: Optional[str] = None
     ownerInstitutionCode: Optional[str] = None
-    scientificName: Optional[str] = None
-    scientificNameAuthorship: Optional[str] = None
-    scientificName_verbatim: Optional[str] = None
+    basisOfRecord: Optional[str] = None
+    preparations: Optional[str] = None
+    hasFragmentPacket: Optional[str] = None
+    disposition: Optional[str] = None
     recordedBy: Optional[str] = None
+    recordedByID: Optional[str] = None
     recordNumber: Optional[str] = None
     eventDate: Optional[str] = None
-    verbatimEventDate: Optional[str] = None
-    eventDateUncertaintyInDays: Optional[str] = None
-    locality: Optional[str] = None
+    eventTime: Optional[str] = None
     country: Optional[str] = None
     stateProvince: Optional[str] = None
+    county: Optional[str] = None
     municipality: Optional[str] = None
+    locality: Optional[str] = None
+    verbatimLocality: Optional[str] = None
+    decimalLatitude: Optional[str] = None
+    decimalLongitude: Optional[str] = None
+    geodeticDatum: Optional[str] = None
+    coordinateUncertaintyInMeters: Optional[str] = None
+    habitat: Optional[str] = None
+    eventRemarks: Optional[str] = None
+    scientificName: Optional[str] = None
+    scientificNameAuthorship: Optional[str] = None
+    taxonRank: Optional[str] = None
+    family: Optional[str] = None
+    genus: Optional[str] = None
+    specificEpithet: Optional[str] = None
+    infraspecificEpithet: Optional[str] = None
+    identificationQualifier: Optional[str] = None
     identifiedBy: Optional[str] = None
     dateIdentified: Optional[str] = None
     identificationRemarks: Optional[str] = None
-    basisOfRecord: Optional[str] = None
-    datasetName: Optional[str] = None
+    identificationReferences: Optional[str] = None
+    identificationVerificationStatus: Optional[str] = None
+    associatedOccurrences: Optional[str] = None
     occurrenceRemarks: Optional[str] = None
+    dynamicProperties: Optional[str] = None
+    scientificName_verbatim: Optional[str] = None
+    verbatimEventDate: Optional[str] = None
+    eventDateUncertaintyInDays: Optional[str] = None
+    datasetName: Optional[str] = None
     verbatimLabel: Optional[str] = None
     flags: Optional[str] = None
 

--- a/io_utils/write.py
+++ b/io_utils/write.py
@@ -6,6 +6,21 @@ import json
 # Use the canonical list of Darwin Core terms defined by the schema module
 from dwc.schema import DWC_TERMS as DWC_COLUMNS
 
+IDENT_HISTORY_COLUMNS = [
+    "occurrenceID",
+    "identificationID",
+    "identifiedBy",
+    "dateIdentified",
+    "scientificName",
+    "scientificNameAuthorship",
+    "taxonRank",
+    "identificationQualifier",
+    "identificationRemarks",
+    "identificationReferences",
+    "identificationVerificationStatus",
+    "isCurrent",
+]
+
 def write_manifest(output_dir: Path, meta: Dict[str, Any]) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = output_dir / "manifest.json"
@@ -13,12 +28,22 @@ def write_manifest(output_dir: Path, meta: Dict[str, Any]) -> None:
 
 def write_dwc_csv(output_dir: Path, rows: Iterable[Dict[str, Any]]) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
-    csv_path = output_dir / "dwc.csv"
+    csv_path = output_dir / "occurrence.csv"
     with csv_path.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=DWC_COLUMNS)
         writer.writeheader()
         for row in rows:
             writer.writerow({k: row.get(k, "") for k in DWC_COLUMNS})
+
+
+def write_identification_history_csv(output_dir: Path, rows: Iterable[Dict[str, Any]]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "identification_history.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=IDENT_HISTORY_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in IDENT_HISTORY_COLUMNS})
 
 def write_jsonl(output_dir: Path, events: Iterable[Dict[str, Any]]) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_cli_ocr.py
+++ b/tests/unit/test_cli_ocr.py
@@ -19,6 +19,7 @@ def _setup(monkeypatch, tmp_path, cfg, dispatch):
     monkeypatch.setattr(cli, "setup_logging", lambda o: None)
     monkeypatch.setattr(cli, "write_jsonl", lambda *a, **k: None)
     monkeypatch.setattr(cli, "write_dwc_csv", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "write_identification_history_csv", lambda *a, **k: None)
     monkeypatch.setattr(cli, "write_manifest", lambda *a, **k: None)
     monkeypatch.setattr(cli.qc, "detect_duplicates", lambda *a, **k: [])
     monkeypatch.setattr(cli.qc, "flag_low_confidence", lambda *a, **k: [])

--- a/tests/unit/test_write.py
+++ b/tests/unit/test_write.py
@@ -5,7 +5,14 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from io_utils.write import write_manifest, write_dwc_csv, write_jsonl, DWC_COLUMNS
+from io_utils.write import (
+    write_manifest,
+    write_dwc_csv,
+    write_jsonl,
+    write_identification_history_csv,
+    DWC_COLUMNS,
+    IDENT_HISTORY_COLUMNS,
+)
 
 def test_write_manifest(tmp_path: Path) -> None:
     meta = {"foo": "bar"}
@@ -17,7 +24,7 @@ def test_write_manifest(tmp_path: Path) -> None:
 def test_write_dwc_csv(tmp_path: Path) -> None:
     rows = [{"catalogNumber": "1", "scientificName": "Test"}]
     write_dwc_csv(tmp_path, rows)
-    csv_path = tmp_path / "dwc.csv"
+    csv_path = tmp_path / "occurrence.csv"
     assert csv_path.exists()
     with csv_path.open() as f:
         reader = csv.DictReader(f)
@@ -27,6 +34,23 @@ def test_write_dwc_csv(tmp_path: Path) -> None:
     assert data[0]["catalogNumber"] == "1"
     assert data[0]["scientificName"] == "Test"
     assert data[0]["collectionCode"] == ""
+
+
+def test_write_identification_history_csv(tmp_path: Path) -> None:
+    rows = [
+        {"occurrenceID": "1", "identificationID": "a", "scientificName": "A", "isCurrent": "TRUE"},
+        {"occurrenceID": "1", "identificationID": "b", "scientificName": "B", "isCurrent": "FALSE"},
+    ]
+    write_identification_history_csv(tmp_path, rows)
+    csv_path = tmp_path / "identification_history.csv"
+    assert csv_path.exists()
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        data = list(reader)
+        fieldnames = reader.fieldnames
+    assert fieldnames == IDENT_HISTORY_COLUMNS
+    assert len(data) == 2
+    assert data[0]["scientificName"] == "A"
 
 def test_write_jsonl(tmp_path: Path) -> None:
     events = [{"id": 1}, {"id": 2}]


### PR DESCRIPTION
## Summary
- Align DWC schema with AAFC-SRDC example, adding Occurrence fields such as `occurrenceID`, geospatial terms, and project-specific extras.
- Rename DWC CSV output to `occurrence.csv` and add writer for `identification_history.csv`.
- Update CLI to extract identification history records and emit both CSV files.
- Extend tests to cover new writers and filenames.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d6d7b114832fbc825a2342a6989c