### PR TITLE
Add prototype OCR preprocessing flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Built-in steps register themselves when `preprocess` is imported, and external
 modules may register additional steps with
 `preprocess.register_preprocessor(name, func)`.
 
+Prototype configurations for Apple Vision, Tesseract, and GPT are documented in
+[`docs/preprocessing_flows.md`](docs/preprocessing_flows.md).
+
 ## Engine plugins
 
 Built-in plugins for Apple Vision (`vision`), Tesseract (`tesseract`), and GPT

--- a/docs/preprocessing_flows.md
+++ b/docs/preprocessing_flows.md
@@ -1,0 +1,37 @@
+# OCR Engine Preprocessing Flows
+
+This document summarizes recommended preprocessing steps for each supported OCR engine. The steps correspond to functions in `preprocess` and can be composed via the `pipeline` list in the configuration file's `[preprocess]` section.
+
+## Apple Vision
+
+| Step     | Purpose                                   | Recommended range |
+|----------|-------------------------------------------|-------------------|
+| `resize` | Limit longest edge for memory efficiency   | `max_dim_px` 2500–3500 (default 3072) |
+
+Apple's Vision framework handles color balance and skew internally, so additional preprocessing is rarely required.
+
+## Tesseract
+
+| Step        | Purpose                                         | Recommended range |
+|-------------|-------------------------------------------------|-------------------|
+| `grayscale` | Remove color information                        | — |
+| `contrast`  | Enhance text/background separation              | `contrast_factor` 1.3–1.7 |
+| `deskew`    | Correct rotation based on principal components  | — |
+| `binarize`  | Otsu threshold to isolate foreground            | — |
+| `resize`    | Improve OCR accuracy at higher resolution       | `max_dim_px` 3000–4000 |
+
+This sequence yields high-quality input for Tesseract by maximizing contrast and text sharpness before recognition.
+
+## GPT (ChatGPT)
+
+| Step        | Purpose                                   | Recommended range |
+|-------------|-------------------------------------------|-------------------|
+| `grayscale` | Simplify image while retaining detail      | — |
+| `contrast`  | Light enhancement to aid tokenization     | `contrast_factor` 1.2–1.5 |
+| `resize`    | Control token count in prompts            | `max_dim_px` 1500–2500 (default 2048) |
+
+GPT-based OCR operates on lower resolutions; moderate preprocessing keeps images concise while remaining legible.
+
+---
+
+Example prototype configurations are available in `preprocess/flows.py` for quick experimentation.

--- a/engines/protocols.py
+++ b/engines/protocols.py
@@ -1,11 +1,10 @@
-from __future__ import annotations
-
-
 """Protocol definitions for engine call signatures.
 
 Third-party engines should implement these protocols so they can be
 registered and dispatched correctly by the :mod:`engines` plugin system.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict, List, Protocol, Tuple

--- a/preprocess/__init__.py
+++ b/preprocess/__init__.py
@@ -5,7 +5,7 @@ import tempfile
 from typing import Dict, Any, Callable
 
 import numpy as np
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, ImageEnhance
 
 _PREPROCESSORS: Dict[str, Callable[[Image.Image, Dict[str, Any]], Image.Image]] = {}
 
@@ -77,6 +77,12 @@ def binarize(image: Image.Image, method: str | bool = "otsu") -> Image.Image:
     return Image.fromarray(binary)
 
 
+def contrast(image: Image.Image, factor: float) -> Image.Image:
+    """Adjust image contrast by ``factor``."""
+    enhancer = ImageEnhance.Contrast(image)
+    return enhancer.enhance(factor)
+
+
 def resize(image: Image.Image, max_dim: int) -> Image.Image:
     """Resize image so that its longest dimension equals ``max_dim``."""
     w, h = image.size
@@ -106,6 +112,16 @@ register_preprocessor("deskew", lambda img, cfg: deskew(img))
 register_preprocessor("binarize", lambda img, cfg: binarize(img))
 
 
+def _contrast_step(img: Image.Image, cfg: Dict[str, Any]) -> Image.Image:
+    factor = cfg.get("contrast_factor")
+    if factor:
+        return contrast(img, float(factor))
+    return img
+
+
+register_preprocessor("contrast", _contrast_step)
+
+
 def _resize_step(img: Image.Image, cfg: Dict[str, Any]) -> Image.Image:
     max_dim = cfg.get("max_dim_px")
     if max_dim:
@@ -120,6 +136,7 @@ __all__ = [
     "grayscale",
     "deskew",
     "binarize",
+    "contrast",
     "resize",
     "preprocess_image",
 ]

--- a/preprocess/flows.py
+++ b/preprocess/flows.py
@@ -1,0 +1,34 @@
+"""Prototype preprocessing flows for different OCR engines."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+# Recommended preprocessing configurations per engine. These dictionaries can
+# be merged into a configuration file's ``[preprocess]`` section.
+
+APPLE_VISION: Dict[str, Any] = {
+    "pipeline": ["resize"],
+    # Apple Vision handles color and skew internally. Limiting size keeps
+    # memory usage reasonable. Values between 2500 and 3500 work well.
+    "max_dim_px": 3072,
+}
+
+TESSERACT: Dict[str, Any] = {
+    # Tesseract benefits from aggressive normalization and binarization.
+    "pipeline": ["grayscale", "contrast", "deskew", "binarize", "resize"],
+    # Contrast factor of 1.3–1.7 sharpens faint text without clipping.
+    "contrast_factor": 1.5,
+    # Resize so the longest edge is around 3000–4000 pixels.
+    "max_dim_px": 4000,
+}
+
+CHATGPT: Dict[str, Any] = {
+    # GPT models operate on lower resolutions but benefit from some cleanup.
+    "pipeline": ["grayscale", "contrast", "resize"],
+    # Slight contrast boost helps legibility; avoid over-enhancement.
+    "contrast_factor": 1.3,
+    # Restrict size to keep prompts small. 1500–2500 pixels works well.
+    "max_dim_px": 2048,
+}
+
+__all__ = ["APPLE_VISION", "TESSERACT", "CHATGPT"]


### PR DESCRIPTION
## Summary
- add contrast preprocessor and expose registry entry
- prototype image-processing configs for Apple Vision, Tesseract, and GPT
- document engine-specific preprocessing flows and parameter ranges

## Testing
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22feb68a0832f85623e8cbbe1dff0