### PR TITLE
Add candidate review CLI with decision logging

### DIFF
--- a/review.py
+++ b/review.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+from typing import List
+
+from io_utils.candidates import Candidate, fetch_candidates, record_decision
+
+
+def review_candidates(db_path: Path, image: str) -> None:
+    """Interactive review of candidate values for an image."""
+    conn = sqlite3.connect(db_path)
+    candidates: List[Candidate] = fetch_candidates(conn, image)
+    if not candidates:
+        print(f"No candidates found for {image}")
+        conn.close()
+        return
+    for idx, cand in enumerate(candidates):
+        print(f"[{idx}] {cand.engine} ({cand.confidence:.2f}): {cand.value}")
+    choice = input("Select preferred candidate [0]: ").strip()
+    sel = int(choice) if choice else 0
+    sel = max(0, min(sel, len(candidates) - 1))
+    record_decision(conn, image, candidates[sel])
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Review OCR candidates")
+    parser.add_argument("db", type=Path, help="Path to candidates database")
+    parser.add_argument("image", help="Image filename to review")
+    args = parser.parse_args()
+    review_candidates(args.db, args.image)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_review_cli.py
+++ b/tests/unit/test_review_cli.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sqlite3
+
+from io_utils.candidates import Candidate, init_db, insert_candidate
+from review import review_candidates
+
+
+def test_review_cli_records_choice(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "candidates.db"
+    conn = init_db(db_path)
+    insert_candidate(
+        conn,
+        "run1",
+        "img1.jpg",
+        Candidate(value="hello", engine="vision", confidence=0.9),
+    )
+    insert_candidate(
+        conn,
+        "run1",
+        "img1.jpg",
+        Candidate(value="hola", engine="tesseract", confidence=0.7),
+    )
+    conn.close()
+
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+    review_candidates(db_path, "img1.jpg")
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT value, engine FROM decisions WHERE image = ?", ("img1.jpg",)
+    ).fetchone()
+    assert row == ("hola", "tesseract")
+    rows = conn.execute(
+        "SELECT value FROM candidates WHERE image = ?", ("img1.jpg",)
+    ).fetchall()
+    assert len(rows) == 2
+    conn.close()


### PR DESCRIPTION
## Summary
- add decision model and table for reviewer selections
- implement `review` CLI to rank candidates by confidence and record chosen value
- store chosen value with engine provenance and timestamp while retaining all candidates

## Testing
- `ruff check io_utils/candidates.py review.py tests/unit/test_review_cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b259798508832f853eca0f7978e953