### PR TITLE
Add provenance tracking to review decisions

### DIFF
--- a/io_utils/candidates.py
+++ b/io_utils/candidates.py
@@ -21,6 +21,7 @@ class Decision(BaseModel):
 
     value: str
     engine: str
+    run_id: str | None
     decided_at: str
 
 
@@ -97,19 +98,22 @@ def record_decision(
     )
     conn.commit()
     return Decision(
-        value=candidate.value, engine=candidate.engine, decided_at=decided_at
+        value=candidate.value,
+        engine=candidate.engine,
+        run_id=run_id,
+        decided_at=decided_at,
     )
 
 
 def fetch_decision(conn: sqlite3.Connection, image: str) -> Optional[Decision]:
     """Retrieve the stored decision for an image if present."""
     row = conn.execute(
-        "SELECT value, engine, decided_at FROM decisions WHERE image = ? ORDER BY decided_at DESC LIMIT 1",
+        "SELECT value, engine, run_id, decided_at FROM decisions WHERE image = ? ORDER BY decided_at DESC LIMIT 1",
         (image,),
     ).fetchone()
     if not row:
         return None
-    return Decision(value=row[0], engine=row[1], decided_at=row[2])
+    return Decision(value=row[0], engine=row[1], run_id=row[2], decided_at=row[3])
 
 
 __all__ = [
@@ -120,4 +124,5 @@ __all__ = [
     "best_candidate",
     "record_decision",
     "fetch_decision",
+    "Decision",
 ]

--- a/tests/unit/test_candidates.py
+++ b/tests/unit/test_candidates.py
@@ -7,6 +7,8 @@ from io_utils.candidates import (
     insert_candidate,
     fetch_candidates,
     best_candidate,
+    record_decision,
+    fetch_decision,
 )
 
 
@@ -32,4 +34,22 @@ def test_candidate_roundtrip(tmp_path: Path) -> None:
     assert [c.engine for c in candidates] == ["vision", "tesseract"]
     best = best_candidate(conn, "img1.jpg")
     assert best and best.engine == "vision"
+    conn.close()
+
+
+def test_record_and_fetch_decision(tmp_path: Path) -> None:
+    db_path = tmp_path / "candidates.db"
+    conn = init_db(db_path)
+    insert_candidate(
+        conn,
+        "run1",
+        "img1.jpg",
+        Candidate(value="hello", engine="vision", confidence=0.9),
+    )
+    decision = record_decision(
+        conn, "img1.jpg", Candidate(value="hello", engine="vision", confidence=0.9)
+    )
+    fetched = fetch_decision(conn, "img1.jpg")
+    assert fetched == decision
+    assert fetched.run_id == "run1"
     conn.close()

--- a/tests/unit/test_review_cli.py
+++ b/tests/unit/test_review_cli.py
@@ -23,12 +23,14 @@ def test_review_cli_records_choice(tmp_path: Path, monkeypatch) -> None:
     conn.close()
 
     monkeypatch.setattr("builtins.input", lambda _: "1")
-    review_candidates(db_path, "img1.jpg")
+    decision = review_candidates(db_path, "img1.jpg")
+    assert decision and decision.engine == "tesseract"
+    assert decision.run_id == "run1"
     conn = sqlite3.connect(db_path)
     row = conn.execute(
-        "SELECT value, engine FROM decisions WHERE image = ?", ("img1.jpg",)
+        "SELECT value, engine, run_id FROM decisions WHERE image = ?", ("img1.jpg",)
     ).fetchone()
-    assert row == ("hola", "tesseract")
+    assert row == ("hola", "tesseract", "run1")
     rows = conn.execute(
         "SELECT value FROM candidates WHERE image = ?", ("img1.jpg",)
     ).fetchall()


### PR DESCRIPTION
## Summary
- sort OCR candidates by confidence for reviewer clarity
- record reviewer selections with engine provenance and timestamp
- test decision persistence and CLI workflow

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b25b7a16ac832fa7f353efe7d023e4