### PR TITLE
Add database schema and CRUD helpers

### DIFF
--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -1,0 +1,62 @@
+# Database Schema
+
+The application uses a lightweight SQLite database to track extraction
+progress and review outcomes. The schema consists of four core tables.
+
+## specimens
+Stores basic information about each specimen.
+
+| column       | type | notes                  |
+|--------------|------|------------------------|
+| specimen_id  | TEXT | primary identifier     |
+| image        | TEXT | path to specimen image |
+
+## candidates
+Holds raw values produced by OCR engines. Includes an `error` flag for
+modules that fail to produce a reliable value.
+
+| column     | type   | notes                          |
+|------------|--------|--------------------------------|
+| run_id     | TEXT   | identifier for the OCR run     |
+| image      | TEXT   | image filename                 |
+| value      | TEXT   | extracted text                 |
+| engine     | TEXT   | OCR engine name                |
+| confidence | REAL   | engine confidence score        |
+| error      | INTEGER| 1 if engine flagged an error   |
+
+## final_values
+Represents the final selected value for each metadata field.
+
+| column      | type   | notes                                  |
+|-------------|--------|----------------------------------------|
+| specimen_id | TEXT   | links back to `specimens`              |
+| field       | TEXT   | metadata field name                    |
+| value       | TEXT   | chosen value                           |
+| module      | TEXT   | module that produced the value         |
+| confidence  | REAL   | confidence for the chosen value        |
+| error       | INTEGER| 1 if reviewers flagged an error        |
+| decided_at  | TEXT   | ISO timestamp of selection             |
+
+## processing_state
+Tracks per-module processing state for each specimen.
+
+| column      | type   | notes                                  |
+|-------------|--------|----------------------------------------|
+| specimen_id | TEXT   | specimen identifier                    |
+| module      | TEXT   | module name                            |
+| status      | TEXT   | e.g. `pending`, `done`, `failed`       |
+| confidence  | REAL   | optional confidence from the module    |
+| error       | INTEGER| 1 if the module reported an error      |
+| updated_at  | TEXT   | ISO timestamp of last update           |
+
+## Migrations
+Run migrations using:
+
+```python
+from pathlib import Path
+from io_utils.migrate import migrate_db
+
+migrate_db(Path("candidates.db"))
+```
+
+This upgrades older databases with the new columns and tables.

--- a/io_utils/database.py
+++ b/io_utils/database.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+from typing import Optional
+
+from pydantic import BaseModel
+
+from .candidates import init_db as init_candidate_db
+
+
+class Specimen(BaseModel):
+    """Represents a herbarium specimen and associated image."""
+
+    specimen_id: str
+    image: str
+
+
+class FinalValue(BaseModel):
+    """Represents the final selected value for a field."""
+
+    specimen_id: str
+    field: str
+    value: str
+    module: str
+    confidence: float
+    error: bool = False
+    decided_at: str | None = None
+
+
+class ProcessingState(BaseModel):
+    """Tracks module processing state for a specimen."""
+
+    specimen_id: str
+    module: str
+    status: str
+    confidence: float | None = None
+    error: bool = False
+    updated_at: str | None = None
+
+
+def init_db(db_path: Path) -> sqlite3.Connection:
+    """Initialise the application database with all required tables."""
+    conn = init_candidate_db(db_path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS specimens (
+            specimen_id TEXT PRIMARY KEY,
+            image TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS final_values (
+            specimen_id TEXT,
+            field TEXT,
+            value TEXT,
+            module TEXT,
+            confidence REAL,
+            error INTEGER DEFAULT 0,
+            decided_at TEXT,
+            PRIMARY KEY (specimen_id, field)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS processing_state (
+            specimen_id TEXT,
+            module TEXT,
+            status TEXT,
+            confidence REAL,
+            error INTEGER DEFAULT 0,
+            updated_at TEXT,
+            PRIMARY KEY (specimen_id, module)
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def insert_specimen(conn: sqlite3.Connection, specimen: Specimen) -> None:
+    """Insert or replace a specimen record."""
+    conn.execute(
+        "INSERT OR REPLACE INTO specimens (specimen_id, image) VALUES (?, ?)",
+        (specimen.specimen_id, specimen.image),
+    )
+    conn.commit()
+
+
+def fetch_specimen(conn: sqlite3.Connection, specimen_id: str) -> Optional[Specimen]:
+    """Fetch a specimen by identifier."""
+    row = conn.execute(
+        "SELECT specimen_id, image FROM specimens WHERE specimen_id = ?",
+        (specimen_id,),
+    ).fetchone()
+    if not row:
+        return None
+    return Specimen(specimen_id=row[0], image=row[1])
+
+
+def insert_final_value(conn: sqlite3.Connection, final: FinalValue) -> FinalValue:
+    """Persist a final value selection and return the stored record."""
+    decided_at = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO final_values (specimen_id, field, value, module, confidence, error, decided_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            final.specimen_id,
+            final.field,
+            final.value,
+            final.module,
+            final.confidence,
+            int(final.error),
+            decided_at,
+        ),
+    )
+    conn.commit()
+    return final.model_copy(update={"decided_at": decided_at})
+
+
+def fetch_final_value(
+    conn: sqlite3.Connection, specimen_id: str, field: str
+) -> Optional[FinalValue]:
+    """Retrieve a final value for the given specimen and field."""
+    row = conn.execute(
+        """
+        SELECT specimen_id, field, value, module, confidence, error, decided_at
+        FROM final_values
+        WHERE specimen_id = ? AND field = ?
+        """,
+        (specimen_id, field),
+    ).fetchone()
+    if not row:
+        return None
+    return FinalValue(
+        specimen_id=row[0],
+        field=row[1],
+        value=row[2],
+        module=row[3],
+        confidence=row[4],
+        error=bool(row[5]),
+        decided_at=row[6],
+    )
+
+
+def upsert_processing_state(
+    conn: sqlite3.Connection, state: ProcessingState
+) -> ProcessingState:
+    """Insert or update processing state for a module."""
+    updated_at = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO processing_state
+            (specimen_id, module, status, confidence, error, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            state.specimen_id,
+            state.module,
+            state.status,
+            state.confidence,
+            int(state.error),
+            updated_at,
+        ),
+    )
+    conn.commit()
+    return state.model_copy(update={"updated_at": updated_at})
+
+
+def fetch_processing_state(
+    conn: sqlite3.Connection, specimen_id: str, module: str
+) -> Optional[ProcessingState]:
+    """Fetch processing state for a specimen/module pair."""
+    row = conn.execute(
+        """
+        SELECT specimen_id, module, status, confidence, error, updated_at
+        FROM processing_state
+        WHERE specimen_id = ? AND module = ?
+        """,
+        (specimen_id, module),
+    ).fetchone()
+    if not row:
+        return None
+    return ProcessingState(
+        specimen_id=row[0],
+        module=row[1],
+        status=row[2],
+        confidence=row[3],
+        error=bool(row[4]),
+        updated_at=row[5],
+    )
+
+
+def migrate(db_path: Path) -> None:
+    """Run database migrations ensuring all tables and columns exist."""
+    conn = init_db(db_path)
+    conn.close()
+
+
+__all__ = [
+    "Specimen",
+    "FinalValue",
+    "ProcessingState",
+    "init_db",
+    "insert_specimen",
+    "fetch_specimen",
+    "insert_final_value",
+    "fetch_final_value",
+    "upsert_processing_state",
+    "fetch_processing_state",
+    "migrate",
+]

--- a/io_utils/migrate.py
+++ b/io_utils/migrate.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from .database import migrate as run_migrate
+
+
+def migrate_db(db_path: Path) -> None:
+    """CLI-friendly helper to run database migrations."""
+    run_migrate(db_path)
+
+
+__all__ = ["migrate_db"]

--- a/tests/unit/test_candidates.py
+++ b/tests/unit/test_candidates.py
@@ -25,13 +25,14 @@ def test_candidate_roundtrip(tmp_path: Path) -> None:
         conn,
         "run1",
         "img1.jpg",
-        Candidate(value="hola", engine="tesseract", confidence=0.7),
+        Candidate(value="hola", engine="tesseract", confidence=0.7, error=True),
     )
     conn.close()
 
     conn = sqlite3.connect(db_path)
     candidates = fetch_candidates(conn, "img1.jpg")
     assert [c.engine for c in candidates] == ["vision", "tesseract"]
+    assert [c.error for c in candidates] == [False, True]
     best = best_candidate(conn, "img1.jpg")
     assert best and best.engine == "vision"
     conn.close()

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from io_utils.database import (
+    FinalValue,
+    ProcessingState,
+    Specimen,
+    fetch_final_value,
+    fetch_processing_state,
+    fetch_specimen,
+    init_db,
+    insert_final_value,
+    insert_specimen,
+    upsert_processing_state,
+)
+
+
+def test_specimen_and_state_roundtrip(tmp_path: Path) -> None:
+    db_path = tmp_path / "app.db"
+    conn = init_db(db_path)
+
+    specimen = Specimen(specimen_id="s1", image="img1.jpg")
+    insert_specimen(conn, specimen)
+    assert fetch_specimen(conn, "s1") == specimen
+
+    state = ProcessingState(
+        specimen_id="s1", module="ocr", status="done", confidence=0.8
+    )
+    stored_state = upsert_processing_state(conn, state)
+    fetched_state = fetch_processing_state(conn, "s1", "ocr")
+    assert fetched_state and fetched_state.status == "done"
+    assert fetched_state.updated_at == stored_state.updated_at
+
+    final = FinalValue(
+        specimen_id="s1",
+        field="scientificName",
+        value="Testus plantus",
+        module="ocr",
+        confidence=0.8,
+    )
+    stored_final = insert_final_value(conn, final)
+    fetched_final = fetch_final_value(conn, "s1", "scientificName")
+    assert fetched_final == stored_final
+    conn.close()


### PR DESCRIPTION
## Summary
- extend candidate model with error flags and persist them in SQLite
- add unified database utilities for specimens, final values, and processing state
- document schema and provide migration helper

## Testing
- `ruff check io_utils/candidates.py io_utils/database.py io_utils/migrate.py tests/unit/test_candidates.py tests/unit/test_database.py --fix`
- `pytest tests/unit/test_candidates.py tests/unit/test_database.py`


------
https://chatgpt.com/codex/tasks/task_e_68b25e31140c832f9391ca344c3566d0