### PR TITLE
Add retry tracking and resume support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -245,9 +245,12 @@ def process_cli(
         "config": cfg,
     }
 
-    write_jsonl(output, events)
-    write_dwc_csv(output, dwc_rows)
-    write_identification_history_csv(output, ident_history_rows)
+    if events:
+        write_jsonl(output, events, append=resume)
+    if dwc_rows:
+        write_dwc_csv(output, dwc_rows, append=resume)
+    if ident_history_rows:
+        write_identification_history_csv(output, ident_history_rows, append=resume)
     write_manifest(output, meta)
     cand_conn.close()
     app_conn.close()

--- a/io_utils/write.py
+++ b/io_utils/write.py
@@ -26,28 +26,41 @@ def write_manifest(output_dir: Path, meta: Dict[str, Any]) -> None:
     manifest_path = output_dir / "manifest.json"
     manifest_path.write_text(json.dumps(meta, indent=2))
 
-def write_dwc_csv(output_dir: Path, rows: Iterable[Dict[str, Any]]) -> None:
+def write_dwc_csv(
+    output_dir: Path, rows: Iterable[Dict[str, Any]], append: bool = False
+) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     csv_path = output_dir / "occurrence.csv"
-    with csv_path.open("w", newline="") as f:
+    file_exists = csv_path.exists()
+    mode = "a" if append and file_exists else "w"
+    with csv_path.open(mode, newline="") as f:
         writer = csv.DictWriter(f, fieldnames=DWC_COLUMNS)
-        writer.writeheader()
+        if not file_exists or mode == "w":
+            writer.writeheader()
         for row in rows:
             writer.writerow({k: row.get(k, "") for k in DWC_COLUMNS})
 
 
-def write_identification_history_csv(output_dir: Path, rows: Iterable[Dict[str, Any]]) -> None:
+def write_identification_history_csv(
+    output_dir: Path, rows: Iterable[Dict[str, Any]], append: bool = False
+) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     csv_path = output_dir / "identification_history.csv"
-    with csv_path.open("w", newline="") as f:
+    file_exists = csv_path.exists()
+    mode = "a" if append and file_exists else "w"
+    with csv_path.open(mode, newline="") as f:
         writer = csv.DictWriter(f, fieldnames=IDENT_HISTORY_COLUMNS)
-        writer.writeheader()
+        if not file_exists or mode == "w":
+            writer.writeheader()
         for row in rows:
             writer.writerow({k: row.get(k, "") for k in IDENT_HISTORY_COLUMNS})
 
-def write_jsonl(output_dir: Path, events: Iterable[Dict[str, Any]]) -> None:
+def write_jsonl(
+    output_dir: Path, events: Iterable[Dict[str, Any]], append: bool = False
+) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     jsonl_path = output_dir / "raw.jsonl"
-    with jsonl_path.open("w") as f:
+    mode = "a" if append and jsonl_path.exists() else "w"
+    with jsonl_path.open(mode) as f:
         for event in events:
             f.write(json.dumps(event) + "\n")

--- a/tests/unit/test_write.py
+++ b/tests/unit/test_write.py
@@ -59,3 +59,47 @@ def test_write_jsonl(tmp_path: Path) -> None:
     assert jsonl_path.exists()
     lines = jsonl_path.read_text().splitlines()
     assert [json.loads(line) for line in lines] == events
+
+
+def test_write_jsonl_appends(tmp_path: Path) -> None:
+    events = [{"id": 1}]
+    write_jsonl(tmp_path, events)
+    write_jsonl(tmp_path, [{"id": 2}], append=True)
+    jsonl_path = tmp_path / "raw.jsonl"
+    lines = jsonl_path.read_text().splitlines()
+    assert [json.loads(line) for line in lines] == [{"id": 1}, {"id": 2}]
+
+
+def test_write_dwc_csv_appends(tmp_path: Path) -> None:
+    rows = [{"catalogNumber": "1"}]
+    write_dwc_csv(tmp_path, rows)
+    write_dwc_csv(tmp_path, [{"catalogNumber": "2"}], append=True)
+    csv_path = tmp_path / "occurrence.csv"
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        data = list(reader)
+    assert [row["catalogNumber"] for row in data] == ["1", "2"]
+
+
+def test_write_identification_history_csv_appends(tmp_path: Path) -> None:
+    rows = [
+        {"occurrenceID": "1", "identificationID": "a", "scientificName": "A", "isCurrent": "TRUE"}
+    ]
+    write_identification_history_csv(tmp_path, rows)
+    write_identification_history_csv(
+        tmp_path,
+        [
+            {
+                "occurrenceID": "2",
+                "identificationID": "b",
+                "scientificName": "B",
+                "isCurrent": "FALSE",
+            }
+        ],
+        append=True,
+    )
+    csv_path = tmp_path / "identification_history.csv"
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        data = list(reader)
+    assert [row["identificationID"] for row in data] == ["a", "b"]


### PR DESCRIPTION
## Summary
- avoid overwriting outputs when resuming runs by appending only new results
- add append-aware write helpers and tests

## Testing
- `ruff check --fix .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b264c98284832fa69ce25d6681d29f