### PR TITLE
Add GBIF verification stubs

### DIFF
--- a/qc/__init__.py
+++ b/qc/__init__.py
@@ -24,13 +24,25 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+from .gbif import (
+    GBIF_REVERSE_GEOCODE_ENDPOINT,
+    GBIF_SPECIES_MATCH_ENDPOINT,
+    LOCALITY_FIELDS,
+    LOCALITY_QUERY_MAP,
+    TAXONOMY_FIELDS,
+    TAXONOMY_QUERY_MAP,
+    GbifLookup,
+)
+
 # Percentage used by ``flag_top_fifth``.  The value represents the size of
 # the top segment (in percent) that should be flagged.  For example a value
 # of 20 means that scan percentages of 80 or higher will be flagged.
 TOP_FIFTH_PCT: float = 20.0
 
 
-def detect_duplicates(catalog: Dict[str, int], sha256: str, phash_threshold: int) -> List[str]:
+def detect_duplicates(
+    catalog: Dict[str, int], sha256: str, phash_threshold: int
+) -> List[str]:
     """Detect duplicate images.
 
     Parameters
@@ -101,5 +113,11 @@ __all__ = [
     "flag_low_confidence",
     "flag_top_fifth",
     "TOP_FIFTH_PCT",
+    "GbifLookup",
+    "GBIF_SPECIES_MATCH_ENDPOINT",
+    "GBIF_REVERSE_GEOCODE_ENDPOINT",
+    "TAXONOMY_QUERY_MAP",
+    "LOCALITY_QUERY_MAP",
+    "TAXONOMY_FIELDS",
+    "LOCALITY_FIELDS",
 ]
-

--- a/qc/gbif.py
+++ b/qc/gbif.py
@@ -1,0 +1,108 @@
+"""GBIF lookup interface for taxonomy and locality verification.
+
+This module outlines the endpoints, parameter mappings, and result fields
+needed to integrate GBIF-based checks into the quality-control pipeline.  It
+contains only type stubs and placeholders for future implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+# GBIF API endpoints used for validation
+GBIF_SPECIES_MATCH_ENDPOINT = "https://api.gbif.org/v1/species/match"
+GBIF_REVERSE_GEOCODE_ENDPOINT = "https://api.gbif.org/v1/geocode/reverse"
+
+# Mapping of local record fields to GBIF query parameters
+TAXONOMY_QUERY_MAP: Dict[str, str] = {
+    "scientificName": "name",
+    "kingdom": "kingdom",
+    "phylum": "phylum",
+    "class": "class",
+    "order": "order",
+    "family": "family",
+    "genus": "genus",
+    "specificEpithet": "species",
+}
+
+LOCALITY_QUERY_MAP: Dict[str, str] = {
+    "decimalLatitude": "lat",
+    "decimalLongitude": "lng",
+}
+
+# Data fields to append or replace after GBIF lookup
+TAXONOMY_FIELDS: List[str] = [
+    "taxonKey",
+    "acceptedTaxonKey",
+    "acceptedScientificName",
+    "scientificName",
+    "rank",
+    "kingdom",
+    "phylum",
+    "class",
+    "order",
+    "family",
+    "genus",
+    "species",
+]
+
+LOCALITY_FIELDS: List[str] = [
+    "country",
+    "countryCode",
+    "stateProvince",
+    "decimalLatitude",
+    "decimalLongitude",
+]
+
+
+@dataclass
+class GbifLookup:
+    """Stub for GBIF lookup operations."""
+
+    def verify_taxonomy(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of ``record`` with taxonomy fields updated.
+
+        Parameters
+        ----------
+        record:
+            Local record containing at least the fields defined in
+            :data:`TAXONOMY_QUERY_MAP`.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Updated record including the fields listed in
+            :data:`TAXONOMY_FIELDS`.
+        """
+
+        raise NotImplementedError("Taxonomy verification not yet implemented.")
+
+    def verify_locality(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of ``record`` with locality fields updated.
+
+        Parameters
+        ----------
+        record:
+            Local record containing at least ``decimalLatitude`` and
+            ``decimalLongitude``.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Updated record including the fields listed in
+            :data:`LOCALITY_FIELDS`.
+        """
+
+        raise NotImplementedError("Locality verification not yet implemented.")
+
+
+__all__ = [
+    "GbifLookup",
+    "GBIF_SPECIES_MATCH_ENDPOINT",
+    "GBIF_REVERSE_GEOCODE_ENDPOINT",
+    "TAXONOMY_QUERY_MAP",
+    "LOCALITY_QUERY_MAP",
+    "TAXONOMY_FIELDS",
+    "LOCALITY_FIELDS",
+]


### PR DESCRIPTION
## Summary
- define GBIF API constants and field mappings for taxonomy and locality checks
- stub `GbifLookup` interface for future GBIF-backed validation
- expose GBIF stubs through `qc` package

## Testing
- `ruff format qc/gbif.py qc/__init__.py`
- `ruff check --fix qc/gbif.py qc/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b267e05694832fac16491929f3aab8