### PR TITLE
Add Darwin Core Archive bundle generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is an early-stage skeleton. The current codebase includes:
 * a Typer-based CLI with a stub `process` command
 * minimal I/O helpers that compute image hashes and write CSV, JSONL, and a
   manifest file
+* archive utilities that generate `meta.xml` and optionally zip outputs into a Darwin Core Archive bundle
 
 Optional OCR engine plugins for Apple Vision, Tesseract, and GPT are available
 and register themselves when their dependencies are installed.

--- a/dwc/__init__.py
+++ b/dwc/__init__.py
@@ -6,6 +6,7 @@ from .validators import (
     validate_minimal_fields,
     validate_event_date,
 )
+from .archive import build_meta_xml, write_meta_xml, build_dwca
 
 __all__ = [
     "DwcRecord",
@@ -16,4 +17,7 @@ __all__ = [
     "validate",
     "validate_minimal_fields",
     "validate_event_date",
+    "build_meta_xml",
+    "write_meta_xml",
+    "build_dwca",
 ]

--- a/dwc/archive.py
+++ b/dwc/archive.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+from xml.etree.ElementTree import Element, SubElement, ElementTree
+import zipfile
+
+from dwc.schema import DWC_TERMS
+from io_utils.write import IDENT_HISTORY_COLUMNS
+
+DWC_NS = "http://rs.tdwg.org/dwc/terms/"
+DC_NS = "http://purl.org/dc/terms/"
+GBIF_NS = "http://rs.gbif.org/terms/1.0/"
+TEXT_NS = "http://rs.tdwg.org/dwc/text/"
+
+IDENT_HISTORY_TERMS: Dict[str, str] = {
+    "occurrenceID": DWC_NS + "occurrenceID",
+    "identificationID": DC_NS + "identifier",
+    "identifiedBy": DWC_NS + "identifiedBy",
+    "dateIdentified": DWC_NS + "dateIdentified",
+    "scientificName": DWC_NS + "scientificName",
+    "scientificNameAuthorship": DWC_NS + "scientificNameAuthorship",
+    "taxonRank": DWC_NS + "taxonRank",
+    "identificationQualifier": DWC_NS + "identificationQualifier",
+    "identificationRemarks": DWC_NS + "identificationRemarks",
+    "identificationReferences": DWC_NS + "identificationReferences",
+    "identificationVerificationStatus": DWC_NS + "identificationVerificationStatus",
+    "isCurrent": GBIF_NS + "isCurrent",
+}
+
+
+def build_meta_xml() -> ElementTree:
+    """Return an :class:`ElementTree` representing Darwin Core meta.xml."""
+    root = Element("meta", xmlns=TEXT_NS)
+
+    core = SubElement(
+        root,
+        "core",
+        encoding="UTF-8",
+        linesTerminatedBy="\n",
+        fieldsTerminatedBy=",",
+        fieldsEnclosedBy='"',
+        ignoreHeaderLines="1",
+        rowType=DWC_NS + "Occurrence",
+    )
+    files = SubElement(core, "files")
+    SubElement(files, "location").text = "occurrence.csv"
+    SubElement(core, "id", index="0")
+    for idx, term in enumerate(DWC_TERMS):
+        SubElement(core, "field", index=str(idx), term=DWC_NS + term)
+
+    ext = SubElement(
+        root,
+        "extension",
+        encoding="UTF-8",
+        linesTerminatedBy="\n",
+        fieldsTerminatedBy=",",
+        fieldsEnclosedBy='"',
+        ignoreHeaderLines="1",
+        rowType=GBIF_NS + "Identification",
+    )
+    files = SubElement(ext, "files")
+    SubElement(files, "location").text = "identification_history.csv"
+    SubElement(ext, "coreid", index="0")
+    for idx, col in enumerate(IDENT_HISTORY_COLUMNS):
+        term = IDENT_HISTORY_TERMS[col]
+        SubElement(ext, "field", index=str(idx), term=term)
+
+    return ElementTree(root)
+
+
+def write_meta_xml(output_dir: Path) -> Path:
+    """Serialize ``meta.xml`` to ``output_dir``."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    meta_path = output_dir / "meta.xml"
+    tree = build_meta_xml()
+    tree.write(meta_path, encoding="UTF-8", xml_declaration=True)
+    return meta_path
+
+
+def build_dwca(output_dir: Path, compress: bool = False) -> Path:
+    """Write ``meta.xml`` and optionally zip into a Darwin Core Archive.
+
+    Parameters
+    ----------
+    output_dir:
+        Directory containing ``occurrence.csv`` and ``identification_history.csv``.
+    compress:
+        If ``True``, produce ``dwca.zip`` containing all components.
+
+    Returns
+    -------
+    Path
+        Path to ``meta.xml`` or the generated zip archive when ``compress`` is
+        ``True``.
+    """
+    meta_path = write_meta_xml(output_dir)
+    if not compress:
+        return meta_path
+
+    archive_path = output_dir / "dwca.zip"
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name in ["occurrence.csv", "identification_history.csv", "meta.xml"]:
+            zf.write(output_dir / name, arcname=name)
+    return archive_path

--- a/tests/integration/test_archive.py
+++ b/tests/integration/test_archive.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import zipfile
+import xml.etree.ElementTree as ET
+
+from dwc.schema import DWC_TERMS
+from io_utils.write import (
+    write_dwc_csv,
+    write_identification_history_csv,
+    IDENT_HISTORY_COLUMNS,
+)
+from dwc.archive import write_meta_xml, build_dwca
+
+
+def _write_csvs(out: Path) -> None:
+    write_dwc_csv(out, [{"occurrenceID": "1"}])
+    write_identification_history_csv(
+        out,
+        [
+            {
+                "occurrenceID": "1",
+                "identificationID": "a",
+                "identifiedBy": "x",
+                "isCurrent": "TRUE",
+            }
+        ],
+    )
+
+
+def test_meta_xml_generation(tmp_path: Path) -> None:
+    _write_csvs(tmp_path)
+    meta_path = write_meta_xml(tmp_path)
+    assert meta_path.exists()
+    tree = ET.parse(meta_path)
+    ns = {"dwc": "http://rs.tdwg.org/dwc/text/"}
+    core_fields = tree.getroot().findall("dwc:core/dwc:field", ns)
+    ext_fields = tree.getroot().findall("dwc:extension/dwc:field", ns)
+    assert len(core_fields) == len(DWC_TERMS)
+    assert len(ext_fields) == len(IDENT_HISTORY_COLUMNS)
+
+
+def test_dwca_zip_contains_all_files(tmp_path: Path) -> None:
+    _write_csvs(tmp_path)
+    zip_path = build_dwca(tmp_path, compress=True)
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+    assert names == {"occurrence.csv", "identification_history.csv", "meta.xml"}

--- a/tests/unit/test_cli_ocr.py
+++ b/tests/unit/test_cli_ocr.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from types import SimpleNamespace
 from PIL import Image
 import pytest
 
@@ -14,6 +12,7 @@ def _setup(monkeypatch, tmp_path, cfg, dispatch):
     monkeypatch.setattr(cli, "load_config", lambda p: cfg)
     monkeypatch.setattr(cli, "dispatch", dispatch)
     import engines
+
     monkeypatch.setattr(engines, "dispatch", dispatch)
     monkeypatch.setattr(cli, "preprocess_image", lambda p, c: p)
     monkeypatch.setattr(cli, "setup_logging", lambda o: None)
@@ -21,6 +20,7 @@ def _setup(monkeypatch, tmp_path, cfg, dispatch):
     monkeypatch.setattr(cli, "write_dwc_csv", lambda *a, **k: None)
     monkeypatch.setattr(cli, "write_identification_history_csv", lambda *a, **k: None)
     monkeypatch.setattr(cli, "write_manifest", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "write_meta_xml", lambda *a, **k: None)
     monkeypatch.setattr(cli.qc, "detect_duplicates", lambda *a, **k: [])
     monkeypatch.setattr(cli.qc, "flag_low_confidence", lambda *a, **k: [])
     monkeypatch.setattr(cli.qc, "flag_top_fifth", lambda *a, **k: [])

--- a/tests/unit/test_cli_preprocess.py
+++ b/tests/unit/test_cli_preprocess.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from PIL import Image
 
 import cli
@@ -20,7 +19,7 @@ def test_process_cli_invokes_preprocess_when_enabled(monkeypatch, tmp_path):
     out_dir.mkdir()
 
     cfg_file = tmp_path / "cfg.toml"
-    cfg_file.write_text("[preprocess]\npipeline=[\"grayscale\"]\n")
+    cfg_file.write_text('[preprocess]\npipeline=["grayscale"]\n')
 
     called = {"n": 0}
 


### PR DESCRIPTION
## Summary
- build `meta.xml` and optional DwC-A ZIP via archive utilities
- export `meta.xml` alongside CSVs in the CLI output
- add integration tests verifying `meta.xml` and archive structure
- document archive utilities in the README

## Testing
- `ruff check dwc/archive.py cli.py dwc/__init__.py tests/integration/test_archive.py tests/unit/test_cli_ocr.py tests/unit/test_cli_preprocess.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b224ce3760832fa99722e5e35ee3e3