### PR TITLE
Add Darwin Core Archive builder

### DIFF
--- a/dwc/__init__.py
+++ b/dwc/__init__.py
@@ -6,6 +6,7 @@ from .validators import (
     validate_minimal_fields,
     validate_event_date,
 )
+from .archive import build_meta_xml, create_archive
 
 __all__ = [
     "DwcRecord",
@@ -16,4 +17,6 @@ __all__ = [
     "validate",
     "validate_minimal_fields",
     "validate_event_date",
+    "build_meta_xml",
+    "create_archive",
 ]

--- a/dwc/archive.py
+++ b/dwc/archive.py
@@ -1,0 +1,134 @@
+"""Utilities for creating Darwin Core Archives.
+
+This module builds a ``meta.xml`` descriptor based on the project's
+``DWC_TERMS`` and the identification history schema used elsewhere in the
+codebase.  The ``meta.xml`` file is written alongside ``occurrence.csv`` and
+``identification_history.csv`` and can optionally be bundled into a ZIP file to
+form a complete Darwin Core Archive (DwC-A).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree.ElementTree import Element, SubElement, tostring
+from xml.dom import minidom
+from zipfile import ZipFile, ZIP_DEFLATED
+from typing import Dict
+
+from .schema import DWC_TERMS
+from io_utils.write import IDENT_HISTORY_COLUMNS
+
+
+def _dwc_term(term: str) -> str:
+    """Return the full Darwin Core URI for a term."""
+
+    return f"http://rs.tdwg.org/dwc/terms/{term}"
+
+
+IDENT_HISTORY_URIS: Dict[str, str] = {
+    "occurrenceID": _dwc_term("occurrenceID"),
+    "identificationID": "http://purl.org/dc/terms/identifier",
+    "identifiedBy": _dwc_term("identifiedBy"),
+    "dateIdentified": _dwc_term("dateIdentified"),
+    "scientificName": _dwc_term("scientificName"),
+    "scientificNameAuthorship": _dwc_term("scientificNameAuthorship"),
+    "taxonRank": _dwc_term("taxonRank"),
+    "identificationQualifier": _dwc_term("identificationQualifier"),
+    "identificationRemarks": _dwc_term("identificationRemarks"),
+    "identificationReferences": _dwc_term("identificationReferences"),
+    "identificationVerificationStatus": _dwc_term(
+        "identificationVerificationStatus"
+    ),
+    "isCurrent": "http://rs.gbif.org/terms/1.0/isCurrent",
+}
+
+
+def build_meta_xml(output_dir: Path) -> Path:
+    """Create ``meta.xml`` for a Darwin Core Archive.
+
+    Parameters
+    ----------
+    output_dir:
+        Directory containing ``occurrence.csv`` and ``identification_history.csv``.
+
+    Returns
+    -------
+    Path to the written ``meta.xml`` file.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    root = Element("meta", xmlns="http://rs.tdwg.org/dwc/text/")
+
+    core = SubElement(
+        root,
+        "core",
+        {
+            "encoding": "UTF-8",
+            "linesTerminatedBy": "\n",
+            "fieldsTerminatedBy": ",",
+            "fieldsEnclosedBy": '"',
+            "ignoreHeaderLines": "1",
+            "rowType": _dwc_term("Occurrence"),
+        },
+    )
+    files_el = SubElement(core, "files")
+    SubElement(files_el, "location").text = "occurrence.csv"
+    SubElement(core, "id", index="0")
+    for idx, term in enumerate(DWC_TERMS):
+        SubElement(core, "field", index=str(idx), term=_dwc_term(term))
+
+    ext = SubElement(
+        root,
+        "extension",
+        {
+            "encoding": "UTF-8",
+            "linesTerminatedBy": "\n",
+            "fieldsTerminatedBy": ",",
+            "fieldsEnclosedBy": '"',
+            "ignoreHeaderLines": "1",
+            "rowType": "http://rs.gbif.org/terms/1.0/Identification",
+        },
+    )
+    files_el = SubElement(ext, "files")
+    SubElement(files_el, "location").text = "identification_history.csv"
+    SubElement(ext, "coreid", index="0")
+    for idx, col in enumerate(IDENT_HISTORY_COLUMNS):
+        uri = IDENT_HISTORY_URIS.get(col, _dwc_term(col))
+        SubElement(ext, "field", index=str(idx), term=uri)
+
+    xml_bytes = tostring(root, encoding="utf-8")
+    pretty = minidom.parseString(xml_bytes).toprettyxml(indent="  ", encoding="UTF-8")
+    meta_path = output_dir / "meta.xml"
+    meta_path.write_bytes(pretty)
+    return meta_path
+
+
+def create_archive(output_dir: Path, *, compress: bool = False) -> Path:
+    """Ensure DwC-A sidecar files exist and optionally create a ZIP archive.
+
+    Parameters
+    ----------
+    output_dir:
+        Directory containing DwC CSV exports.
+    compress:
+        If ``True``, a ``dwca.zip`` file will be created in ``output_dir``
+        containing the CSV files and ``meta.xml``.
+
+    Returns
+    -------
+    Path to ``meta.xml`` if ``compress`` is ``False``; otherwise the path to the
+    created ZIP file.
+    """
+
+    meta_path = build_meta_xml(output_dir)
+    if not compress:
+        return meta_path
+
+    archive_path = output_dir / "dwca.zip"
+    with ZipFile(archive_path, "w", ZIP_DEFLATED) as zf:
+        for name in ["occurrence.csv", "identification_history.csv", "meta.xml"]:
+            file_path = output_dir / name
+            if file_path.exists():
+                zf.write(file_path, arcname=name)
+    return archive_path
+

--- a/tests/integration/test_archive.py
+++ b/tests/integration/test_archive.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import xml.etree.ElementTree as ET
+import zipfile
+
+from dwc.archive import create_archive
+from dwc.schema import DWC_TERMS
+from io_utils.write import (
+    write_dwc_csv,
+    write_identification_history_csv,
+    IDENT_HISTORY_COLUMNS,
+)
+
+
+def _prepare_csvs(output_dir: Path) -> None:
+    write_dwc_csv(output_dir, [])
+    write_identification_history_csv(output_dir, [])
+
+
+def test_meta_xml_written(tmp_path: Path) -> None:
+    _prepare_csvs(tmp_path)
+    create_archive(tmp_path, compress=False)
+    meta_path = tmp_path / "meta.xml"
+    assert meta_path.exists()
+
+    tree = ET.parse(meta_path)
+    ns = {"dwc": "http://rs.tdwg.org/dwc/text/"}
+    core = tree.getroot().find("dwc:core", ns)
+    assert core is not None
+    fields = core.findall("dwc:field", ns)
+    assert len(fields) == len(DWC_TERMS)
+
+    ext = tree.getroot().find("dwc:extension", ns)
+    assert ext is not None
+    ext_fields = ext.findall("dwc:field", ns)
+    assert len(ext_fields) == len(IDENT_HISTORY_COLUMNS)
+
+
+def test_zip_archive_contains_required_files(tmp_path: Path) -> None:
+    _prepare_csvs(tmp_path)
+    archive_path = create_archive(tmp_path, compress=True)
+    assert archive_path.exists()
+
+    with zipfile.ZipFile(archive_path) as zf:
+        names = set(zf.namelist())
+        assert {"occurrence.csv", "identification_history.csv", "meta.xml"} <= names


### PR DESCRIPTION
## Summary
- generate `meta.xml` from project schemas and bundle with CSV exports
- option to compress DwC files into a ZIP archive
- integration tests verify `meta.xml` contents and archive structure

## Testing
- `ruff check --fix .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b274e27f48832f8e508b0438da7913