### PR TITLE
Configure Ruff linting and formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,15 @@ dev = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
## Summary
- add Ruff configuration with line length 100, py311 target, and formatting preferences
- ignore E501 and set default lint rules

## Testing
- `ruff --fix .` (fails: unexpected argument '--fix')
- `ruff check --fix .`
- `ruff .` (fails: unrecognized subcommand '.')
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3bdcbf49c832fb3f248978eca56e4