### PR TITLE
docs: add development guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,21 @@
 # AGENTS.md
 
 ## Data & Folder Conventions
-- **Fields:** refer to 'examples/AAFC-SRDC/meta.json' for herbarium data conventions.
+- **Fields:** refer to `examples/AAFC-SRDC/meta.json` for herbarium data conventions.
 - **Input:** place source images or other inbound data under `./input/`; nested subdirectories allowed.
 - **Output:** write all generated artifacts to `./output/`.
 - **Database:** use a lightweight SQLite database to track progress, deduplicate work, and resume runs.
-- **Exports:** when creating CSV or spreadsheet files, generate them from the intermediate database—never parse existing output files.
+- **Exports:** generate CSV, spreadsheet, or DwC-A files from the intermediate database—never parse existing output files.
+
+## Digitization Workflow & Separation
+- Run preprocessing, OCR, candidate extraction, and refinement outside the central DwC+ABCD store.
+- The main database only ingests curated values; keep raw artifacts and provenance (image hash, OCR engine, confidence) in the pipeline's SQLite store.
+- Treat imports as an explicit, auditable step with no hidden side effects.
+
+## Export Versioning
+- Support export formats: filtered CSV, Excel, pivot tables, JSONL, and zipped DwC-A bundles.
+- Tag each export with timestamp, filter criteria, and commit hash to ensure reproducibility.
+- Store exported artifacts under `./output/` with semantic version tags.
 
 ## Coding Style & Tooling
 - Use **Ruff** for both linting and formatting.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Documentation Guidelines
+- Use Markdown with sentence-case headings.
+- Organize content by workflow phase: preprocessing, OCR, mapping, QC, import, and export.
+- Provide relative links to code or other docs instead of duplicating explanations.
+- Highlight the separation between the digitization pipeline and the main DwC+ABCD database when relevant.
+- Examples should be reproducible via repository scripts; do not paste hand-edited outputs.
+
+## Testing
+- Run `ruff .` and `pytest` from the repository root before committing documentation changes.

--- a/dwc/AGENTS.md
+++ b/dwc/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+## Darwin Core & ABCD Modules
+- `schema.py` defines the canonical list of supported Darwin Core terms. Update it when adding new terms and keep ordering consistent.
+- Add mapping logic in `mapper.py` and normalization rules in `normalize.py`; keep functions small and pure.
+- When adding ABCD fields, provide a comment with the equivalent term and update validators accordingly.
+- Expand unit tests to cover new terms or transformations.
+
+## Testing
+- After changes in this directory, run `ruff dwc` and the project test suite (`pytest`) from the repository root.


### PR DESCRIPTION
## Summary
- Expand root AGENTS instructions with workflow separation and export versioning guidelines
- Add documentation style guide under `docs/`
- Add Darwin Core mapping guidance under `dwc/`

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d6f42dc4832f96bde0dbd72f326d