### PR TITLE
✨ Add GPT image-to-DwC engine and prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - support GPT image-to-Darwin Core extraction with default prompts
 
+### Fixed
+- guard against non-dict GPT responses to avoid crashes
+
 ## 0.1.0 - 2025-09-01
 
 - document configuration files and GPT usage

--- a/engines/gpt/image_to_dwc.py
+++ b/engines/gpt/image_to_dwc.py
@@ -51,6 +51,8 @@ def image_to_dwc(
     content = getattr(resp, "output_text", "{}")
     try:
         data = json.loads(content)
+        if not isinstance(data, dict):
+            raise EngineError("PARSE_ERROR", "Response is not a JSON object")
     except Exception as exc:
         raise EngineError("PARSE_ERROR", str(exc)) from exc
 


### PR DESCRIPTION
## Summary
- guard against non-dict GPT responses to avoid crashes
- reconcile changelog entries for GPT extraction

## Testing
- `ruff check --fix engines/gpt/image_to_dwc.py`
- `ruff format engines/gpt/image_to_dwc.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d56265c8832f9dd26045cfbc17f1