### PR TITLE
fix: handle missing user prompts in GPT engines

### DIFF
--- a/engines/gpt/image_to_text.py
+++ b/engines/gpt/image_to_text.py
@@ -27,6 +27,12 @@ def load_messages(task: str, prompt_dir: Optional[Path] = None) -> List[Dict[str
         file = base.joinpath(f"{task}.{role}.prompt")
         if file.is_file():
             messages.append({"role": role, "content": file.read_text(encoding="utf-8")})
+    if not messages or messages[-1]["role"] != "user":
+        legacy = base.joinpath(f"{task}.prompt")
+        if legacy.is_file():
+            messages.append({"role": "user", "content": legacy.read_text(encoding="utf-8")})
+    if not messages or messages[-1]["role"] != "user":
+        raise EngineError("MISSING_PROMPT", f"user prompt for {task} not found")
     return messages
 
 

--- a/engines/gpt/text_to_dwc.py
+++ b/engines/gpt/text_to_dwc.py
@@ -27,6 +27,12 @@ def load_messages(task: str, prompt_dir: Optional[Path] = None) -> List[Dict[str
         file = base.joinpath(f"{task}.{role}.prompt")
         if file.is_file():
             messages.append({"role": role, "content": file.read_text(encoding="utf-8")})
+    if not messages or messages[-1]["role"] != "user":
+        legacy = base.joinpath(f"{task}.prompt")
+        if legacy.is_file():
+            messages.append({"role": "user", "content": legacy.read_text(encoding="utf-8")})
+    if not messages or messages[-1]["role"] != "user":
+        raise EngineError("MISSING_PROMPT", f"user prompt for {task} not found")
     return messages
 
 


### PR DESCRIPTION
## Summary
- fallback to legacy `.prompt` files when role-based user prompt is absent
- raise `MISSING_PROMPT` before indexing to avoid crashes

## Testing
- `ruff check --fix .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0539734832fa2ee9adbff99cd73