### PR TITLE
Add review bundle export/import workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - :gear: configurable task pipeline via `pipeline.steps`
 - :sparkles: interactive candidate review TUI using Textual
 - :sparkles: lightweight web review server for OCR candidate selection
+- :sparkles: export/import review bundles with manifest and semantic versioning
 
 ### Fixed
 - guard against non-dict GPT responses to avoid crashes

--- a/docs/review_workflow.md
+++ b/docs/review_workflow.md
@@ -1,22 +1,10 @@
 # Review workflow
 
-## Preprocessing
-Place source images under `input/` before running OCR.
+## Export
+Use [export_review.py](../export_review.py) to package images, `candidates.db`, and a JSON manifest. The script writes bundles such as `review_v1.2.0.zip` to `output/` and records the current commit hash and schema version.
 
-## OCR
-Run the extraction pipeline to populate [candidates.db](../io_utils/candidates.py) with OCR outputs.
-
-## QC
-Start the lightweight web reviewer to confirm candidate values alongside their images:
-
-```bash
-python review_web.py --db candidates.db --images input/
-```
-
-Selections are written to a SQLite database separate from the main DwC+ABCD store.
+## Transfer
+Upload the bundle to SharePoint or attach it to an email for manual review. Keep the file intact so the manifest, images, and database remain synchronized.
 
 ## Import
-Review decisions must be imported explicitly into the primary database.
-
-## Export
-Exports should embed the commit hash and export version for reproducibility. See [review_web.py](../review_web.py) for details.
+When decisions are returned, run [import_review.py](../import_review.py) with the expected schema version. The script validates the commit hash and prevents duplicate decision records before merging updates into the local database.

--- a/export_review.py
+++ b/export_review.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def build_manifest(schema_version: str) -> dict[str, str]:
+    commit = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    )
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return {
+        "timestamp": timestamp,
+        "commit": commit,
+        "schema_version": schema_version,
+    }
+
+
+def package_review(db_path: Path, images_dir: Path, schema_version: str) -> Path:
+    """Create a review bundle containing images, database, and manifest."""
+    if not SEMVER_RE.match(schema_version):
+        raise ValueError("schema version must follow semantic versioning")
+    output_dir = Path("output")
+    output_dir.mkdir(exist_ok=True)
+    bundle_name = f"review_v{schema_version}.zip"
+    bundle_path = output_dir / bundle_name
+    manifest = build_manifest(schema_version)
+    with zipfile.ZipFile(bundle_path, "w") as zf:
+        zf.write(db_path, "candidates.db")
+        for img in images_dir.rglob("*"):
+            if img.is_file():
+                zf.write(img, Path("images") / img.relative_to(images_dir))
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2))
+    return bundle_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Package review bundle")
+    parser.add_argument("db", type=Path, help="Path to candidates database")
+    parser.add_argument("images", type=Path, help="Directory of source images")
+    parser.add_argument(
+        "--schema-version", required=True, help="Schema version (e.g. 1.2.0)"
+    )
+    args = parser.parse_args()
+    package_review(args.db, args.images, args.schema_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/import_review.py
+++ b/import_review.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+from io_utils.candidates import import_decisions, init_db
+
+
+def verify_manifest(manifest: dict, expected_version: str) -> None:
+    commit = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    )
+    if manifest.get("commit") != commit:
+        raise RuntimeError("commit hash mismatch")
+    if manifest.get("schema_version") != expected_version:
+        raise RuntimeError("schema version mismatch")
+
+
+def import_bundle(bundle: Path, db_path: Path, schema_version: str) -> None:
+    with zipfile.ZipFile(bundle) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+        verify_manifest(manifest, schema_version)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zf.extract("candidates.db", tmpdir)
+            src_conn = sqlite3.connect(Path(tmpdir) / "candidates.db")
+            dest_conn = init_db(db_path)
+            import_decisions(dest_conn, src_conn)
+            src_conn.close()
+            dest_conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import reviewed decisions")
+    parser.add_argument("bundle", type=Path, help="Path to review bundle zip")
+    parser.add_argument("db", type=Path, help="Local candidates database")
+    parser.add_argument(
+        "--schema-version", required=True, help="Expected schema version"
+    )
+    args = parser.parse_args()
+    import_bundle(args.bundle, args.db, args.schema_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- package images, candidates.db, and manifest into versioned review bundles
- import reviewed decisions with commit/schema validation and duplicate checks
- document review bundle workflow

## Testing
- `ruff check . --fix`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b64c9f0e0c832fa2fc1e9e912f9e9a