### PR TITLE
fix: deduplicate decisions on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - guard against non-dict GPT responses to avoid crashes
+- handle multiple reviewer decisions per image when importing review bundles
 
 ### Changed
 - :recycle: load role-based GPT prompts and pass messages directly to the API


### PR DESCRIPTION
## Summary
- handle multiple reviewer decisions per image during import
- add tests for review decision importing
- document decision deduplication in changelog

## Testing
- `ruff check . --fix`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b65a0104c8832f969458a311468e51