### PR TITLE
✨ add spreadsheet review utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - :sparkles: interactive candidate review TUI using Textual
 - :sparkles: lightweight web review server for OCR candidate selection
 - :sparkles: export/import review bundles with manifest and semantic versioning
+- :sparkles: spreadsheet utilities for Excel and Google Sheets review
 
 ### Fixed
 - guard against non-dict GPT responses to avoid crashes

--- a/docs/review_workflow.md
+++ b/docs/review_workflow.md
@@ -6,5 +6,24 @@ Use [export_review.py](../export_review.py) to package images, `candidates.db`, 
 ## Transfer
 Upload the bundle to SharePoint or attach it to an email for manual review. Keep the file intact so the manifest, images, and database remain synchronized.
 
+## Spreadsheet review
+Use [io_utils/spreadsheets.py](../io_utils/spreadsheets.py) to export candidate rows to an Excel file:
+
+```python
+from io_utils.spreadsheets import export_candidates_to_spreadsheet
+
+export_candidates_to_spreadsheet(conn, "1.0.0", Path("output/review.xlsx"))
+```
+
+Upload the `.xlsx` file to SharePoint for reviewers. They mark the `selected` column for accepted values. After collaboration, download the file and import decisions:
+
+```python
+from io_utils.spreadsheets import import_review_selections
+
+decisions = import_review_selections(Path("output/review.xlsx"), "1.0.0")
+```
+
+The import step validates the manifest's commit hash and schema version before returning selections for ingestion.
+
 ## Import
 When decisions are returned, run [import_review.py](../import_review.py) with the expected schema version. The script validates the commit hash and prevents duplicate decision records before merging updates into the local database.

--- a/io_utils/__init__.py
+++ b/io_utils/__init__.py
@@ -1,0 +1,11 @@
+from .spreadsheets import (
+    export_candidates_to_spreadsheet,
+    import_review_selections,
+    build_manifest,
+)
+
+__all__ = [
+    "export_candidates_to_spreadsheet",
+    "import_review_selections",
+    "build_manifest",
+]

--- a/io_utils/spreadsheets.py
+++ b/io_utils/spreadsheets.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+import subprocess
+from typing import List, Dict, Any
+
+import pyexcel
+
+
+def build_manifest(schema_version: str) -> Dict[str, str]:
+    """Create version metadata with commit hash and timestamp."""
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return {"commit": commit, "timestamp": timestamp, "schema_version": schema_version}
+
+
+def export_candidates_to_spreadsheet(
+    conn: sqlite3.Connection,
+    schema_version: str,
+    output_path: Path,
+    gsheet_title: str | None = None,
+    creds_path: Path | None = None,
+) -> Path:
+    """
+    Export all candidate records to an Excel spreadsheet with manifest metadata.
+
+    If ``gsheet_title`` and ``creds_path`` are provided, also upload to Google Sheets.
+    """
+    rows = conn.execute(
+        "SELECT run_id, image, value, engine, confidence, error FROM candidates"
+    ).fetchall()
+    header = ["run_id", "image", "value", "engine", "confidence", "error", "selected"]
+    sheet = [header]
+    for row in rows:
+        sheet.append(list(row) + [""])
+    manifest = build_manifest(schema_version)
+    manifest_sheet = [["key", "value"]] + [[k, v] for k, v in manifest.items()]
+    pyexcel.save_book_as(
+        bookdict={"candidates": sheet, "manifest": manifest_sheet},
+        dest_file_name=str(output_path),
+    )
+
+    if gsheet_title and creds_path:
+        import pygsheets
+
+        gc = pygsheets.authorize(service_file=str(creds_path))
+        sh = gc.create(gsheet_title)
+        sh.sheet1.update_values("A1", sheet)
+        manifest_ws = sh.add_worksheet("manifest")
+        manifest_ws.update_values("A1", manifest_sheet)
+    return output_path
+
+
+def import_review_selections(
+    spreadsheet: Path, schema_version: str
+) -> List[Dict[str, Any]]:
+    """Read reviewer selections and validate manifest data."""
+    book = pyexcel.get_book(file_name=str(spreadsheet))
+    manifest_sheet = book["manifest"]
+    manifest_rows = list(manifest_sheet.array)
+    manifest = {row[0]: row[1] for row in manifest_rows[1:]}
+
+    expected = build_manifest(schema_version)
+    for key in ("commit", "schema_version"):
+        if manifest.get(key) != expected[key]:
+            raise ValueError(f"manifest mismatch for {key}")
+
+    cand_sheet = book["candidates"]
+    cand_sheet.name_columns_by_row(0)
+    decisions: List[Dict[str, Any]] = []
+    for record in cand_sheet.to_records():
+        selected = str(record.get("selected", "")).strip().lower()
+        if selected in {"1", "true", "yes", "y"}:
+            decisions.append(
+                {
+                    "run_id": record.get("run_id"),
+                    "image": record.get("image"),
+                    "value": record.get("value"),
+                    "engine": record.get("engine"),
+                }
+            )
+    return decisions
+
+
+__all__ = ["export_candidates_to_spreadsheet", "import_review_selections", "build_manifest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "sqlalchemy",
     "python-dotenv",
     "textual",
+    "pyexcel",
+    "pyexcel-xlsx",
+    "pygsheets",
 ]
 
 [project.scripts]

--- a/tests/unit/test_spreadsheets.py
+++ b/tests/unit/test_spreadsheets.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pyexcel
+import pytest
+
+from io_utils.candidates import Candidate, init_db, insert_candidate
+from io_utils.spreadsheets import (
+    export_candidates_to_spreadsheet,
+    import_review_selections,
+)
+
+
+def test_export_and_import_roundtrip(tmp_path: Path) -> None:
+    db = tmp_path / "candidates.db"
+    conn = init_db(db)
+    insert_candidate(
+        conn,
+        "run1",
+        "img1.jpg",
+        Candidate(value="foo", engine="vision", confidence=0.9),
+    )
+    export_path = tmp_path / "review.xlsx"
+    export_candidates_to_spreadsheet(conn, "1.0.0", export_path)
+    book = pyexcel.get_book(file_name=str(export_path))
+    sheet = book["candidates"]
+    sheet[1, 6] = "1"
+    book.save_as(str(export_path))
+    decisions = import_review_selections(export_path, "1.0.0")
+    assert decisions == [
+        {"run_id": "run1", "image": "img1.jpg", "value": "foo", "engine": "vision"}
+    ]
+
+
+def test_manifest_mismatch(tmp_path: Path) -> None:
+    db = tmp_path / "candidates.db"
+    conn = init_db(db)
+    export_path = tmp_path / "review.xlsx"
+    export_candidates_to_spreadsheet(conn, "1.0.0", export_path)
+    with pytest.raises(ValueError):
+        import_review_selections(export_path, "9.9.9")


### PR DESCRIPTION
## Summary
- add pyexcel/pygsheets helpers for exporting candidate data with manifest metadata
- import reviewer selections from spreadsheets with manifest validation
- document SharePoint spreadsheet review flow

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b67ff8bae8832f83d22f1f5bf40d57