### PR TITLE
docs: correct review workflow commands

### DIFF
--- a/docs/review_workflow.md
+++ b/docs/review_workflow.md
@@ -7,23 +7,23 @@ Export candidates to a self-contained bundle, review selections outside the main
 Use [export_review.py](../export_review.py) to package `candidates.db`, images, and a manifest into `output/review_vX.Y.Z.zip`.
 
 ```
-python export_review.py --output output/review_v1.2.0.zip
+python export_review.py output/candidates.db input/images --schema-version 1.2.0
 ```
 
 ## TUI review
 
-The [review_tui.py](../review_tui.py) script provides a text-based interface using the exported SQLite database. Selections are written back to the same database, keeping review separate from the central store.
+Launch the text-based interface via [review.py](../review.py) with the `--tui` flag. Decisions are written back to the exported database, keeping review separate from the central store.
 
 - **Windows**
 
   ```
-  py review_tui.py output/candidates.db image.jpg
+  py review.py --tui output/candidates.db image.jpg
   ```
 
 - **macOS/Linux**
 
   ```
-  python3 review_tui.py output/candidates.db image.jpg
+  python3 review.py --tui output/candidates.db image.jpg
   ```
 
 ## Web UI review
@@ -48,39 +48,29 @@ Visit `http://localhost:8000` to start reviewing.
 
 Use [io_utils/spreadsheets.py](../io_utils/spreadsheets.py) for teams that prefer spreadsheets.
 
-Export candidates:
+```python
+import sqlite3
+from pathlib import Path
 
-- **Windows**
+from io_utils.candidates import Candidate, record_decision
+from io_utils.spreadsheets import (
+    export_candidates_to_spreadsheet,
+    import_review_selections,
+)
 
-  ```
-  py -m io_utils.spreadsheets export output/candidates.db output/review.xlsx
-  ```
+conn = sqlite3.connect("output/candidates.db")
+export_candidates_to_spreadsheet(conn, "1.2.0", Path("output/review.xlsx"))
 
-- **macOS/Linux**
-
-  ```
-  python3 -m io_utils.spreadsheets export output/candidates.db output/review.xlsx
-  ```
-
-After reviewers mark the `selected` column, import the decisions:
-
-- **Windows**
-
-  ```
-  py -m io_utils.spreadsheets import output/review.xlsx output/candidates.db
-  ```
-
-- **macOS/Linux**
-
-  ```
-  python3 -m io_utils.spreadsheets import output/review.xlsx output/candidates.db
-  ```
+# After reviewers mark the 'selected' column
+for d in import_review_selections(Path("output/review.xlsx"), "1.2.0"):
+    record_decision(conn, d["image"], Candidate(d["value"], d["engine"], 1.0))
+```
 
 ## Import decisions
 
 Merge reviewed selections back into your working database with [import_review.py](../import_review.py):
 
 ```
-python import_review.py output/review_v1.2.0.zip
+python import_review.py output/review_v1.2.0.zip output/candidates.db --schema-version 1.2.0
 ```
 


### PR DESCRIPTION
## Summary
- fix `export_review.py` example to show database, images dir, and schema version
- use `review.py --tui` for text interface launch
- replace spreadsheet CLI examples with Python snippet
- document required args for `import_review.py`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b715ff2d08832f8797db4e1ef497fe