### PR TITLE
🐛 fix Windows path handling when opening images

### DIFF
--- a/review.py
+++ b/review.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 import sqlite3
-import subprocess
 import sys
 import webbrowser
+import os
 from pathlib import Path
 from typing import List
 
@@ -14,7 +14,7 @@ from io_utils.candidates import Candidate, Decision, fetch_candidates, record_de
 def _open_image(image: str) -> None:
     """Open an image in the default viewer."""
     if sys.platform.startswith("win"):
-        subprocess.run(["start", image], check=False, shell=True)
+        os.startfile(image)  # type: ignore[attr-defined]
     else:
         webbrowser.open(Path(image).resolve().as_uri())
 


### PR DESCRIPTION
## Summary
- use `os.startfile` on Windows to handle paths with spaces

## Testing
- `ruff check --fix review.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7cc98edfc832f94c012c069c7416a