### PR TITLE
Standardize review TUI invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ python cli.py resume  --input PATH/TO/images --output PATH/TO/output \
 
 Review exported candidates using the text-based UI, a browser, or spreadsheets. Each option operates on a review bundle rather than the main database.
 
-- Text UI: `python review_tui.py output/candidates.db IMAGE.JPG`
+- Text UI: `python review.py output/candidates.db IMAGE.JPG --tui`
 - Web UI: `python review_web.py --db output/candidates.db --images output`
 - Spreadsheet flow: see [`io_utils/spreadsheets.py`](io_utils/spreadsheets.py)
 

--- a/docs/review_workflow.md
+++ b/docs/review_workflow.md
@@ -12,7 +12,7 @@ python export_review.py output/candidates.db input --schema-version 1.2.0
 
 ## TUI review
 
-Launch the text-based interface via the `--tui` option in [review.py](../review.py). Selections are written back to the same database, keeping review separate from the central store.
+Launch the text-based interface with `python review.py output/candidates.db image.jpg --tui`. Selections are written back to the same database, keeping review separate from the central store.
 
 - **Windows**
 

--- a/review_tui.py
+++ b/review_tui.py
@@ -69,3 +69,7 @@ class ReviewApp(App[Decision | None]):
 def review_candidates_tui(db_path: Path, image: str) -> Decision | None:
     """Launch the Textual UI for candidate review."""
     return ReviewApp(db_path, image).run()
+
+
+if __name__ == "__main__":
+    raise SystemExit("Use 'python review.py --tui' to launch the text interface.")


### PR DESCRIPTION
## Summary
- clarify `review.py --tui` as the canonical text UI command
- document TUI invocation consistently across docs
- prevent running `review_tui.py` directly

## Testing
- `ruff check . --fix`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7d69c34bc832fa27b6b58813ef365