### PR TITLE
Expose contrast factor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See [docs/review_workflow.md](docs/review_workflow.md) for OS-specific commands 
 - **OCR** – `preferred_engine`, `enabled_engines`, `allow_gpt`, `allow_tesseract_on_macos`, `confidence_threshold`
 - **GPT** – `model`, `dry_run`, `fallback_threshold`
 - **Tesseract** – `oem`, `psm`, `langs`, `extra_args`
-- **Preprocess** – `pipeline = ["grayscale","deskew","binarize","resize"]`, `max_dim_px`, `contrast_factor`
+- **Preprocess** – `pipeline = ["grayscale","deskew","binarize","resize"]`, `max_dim_px`, optional `contrast_factor` (used when `"contrast"` is in the pipeline)
 - **DWc mapping** – `assume_country_if_missing`, `strict_minimal_fields`, normalization toggles
 - **QC** – duplicate detection (`phash_threshold`), low-confidence flagging, top-fifth scan flag
 - **Processing** – `retry_limit` for failed specimens
@@ -110,6 +110,7 @@ Preprocessing steps are registered via `preprocess.register_preprocessor`. Confi
 [preprocess]
 pipeline   = ["grayscale", "deskew", "binarize", "resize"]
 max_dim_px = 4000
+contrast_factor = 1.5  # used when "contrast" is in the pipeline
 ```
 
 Prototype flows for each engine are documented in `docs/preprocessing_flows.md`.

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -32,6 +32,7 @@ steps = ["image_to_text", "text_to_dwc"]
 pipeline = ["grayscale", "deskew", "binarize", "resize"]
 binarize = "adaptive_sauvola"
 max_dim_px = 4000
+contrast_factor = 1.5  # used when "contrast" is in the pipeline
 
 [dwc]
 schema = "dwc-abcd"

--- a/docs/preprocessing_flows.md
+++ b/docs/preprocessing_flows.md
@@ -15,7 +15,7 @@ Apple's Vision framework handles color balance and skew internally, so additiona
 | Step        | Purpose                                         | Recommended range |
 |-------------|-------------------------------------------------|-------------------|
 | `grayscale` | Remove color information                        | — |
-| `contrast`  | Enhance text/background separation              | `contrast_factor` 1.3–1.7 |
+| `contrast`  | Enhance text/background separation              | `contrast_factor` 1.3–1.7 (default 1.5) |
 | `deskew`    | Correct rotation based on principal components  | — |
 | `binarize`  | Otsu threshold to isolate foreground            | — |
 | `resize`    | Improve OCR accuracy at higher resolution       | `max_dim_px` 3000–4000 |
@@ -27,7 +27,7 @@ This sequence yields high-quality input for Tesseract by maximizing contrast and
 | Step        | Purpose                                   | Recommended range |
 |-------------|-------------------------------------------|-------------------|
 | `grayscale` | Simplify image while retaining detail      | — |
-| `contrast`  | Light enhancement to aid tokenization     | `contrast_factor` 1.2–1.5 |
+| `contrast`  | Light enhancement to aid tokenization     | `contrast_factor` 1.2–1.5 (default 1.3) |
 | `resize`    | Control token count in prompts            | `max_dim_px` 1500–2500 (default 2048) |
 
 GPT-based OCR operates on lower resolutions; moderate preprocessing keeps images concise while remaining legible.


### PR DESCRIPTION
## Summary
- add `contrast_factor` to default preprocessing config
- document optional contrast usage and defaults in README and preprocessing flow guide

## Testing
- `ruff check . --fix`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7d710aeb8832f86543bf121a8bb21