### PR TITLE
✨ Add adaptive thresholding preprocessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased] (0.1.4)
 
+### Added
+- ✨ adaptive threshold preprocessor with selectable Otsu or Sauvola binarization
+
+### Docs
+- 📝 document adaptive thresholding options in preprocessing and configuration guides
+
 ## [0.1.3] - 2025-09-08 (0.1.3)
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See [docs/review_workflow.md](docs/review_workflow.md) for OS-specific commands 
 - **OCR** – `preferred_engine`, `enabled_engines`, `allow_gpt`, `allow_tesseract_on_macos`, `confidence_threshold`
 - **GPT** – `model`, `dry_run`, `fallback_threshold`
 - **Tesseract** – `oem`, `psm`, `langs`, `extra_args`
-- **Preprocess** – `pipeline = ["grayscale","deskew","binarize","resize"]`, `max_dim_px`, optional `contrast_factor` (used when `"contrast"` is in the pipeline)
+- **Preprocess** – `pipeline = ["grayscale","deskew","binarize","resize"]`, `binarize_method`, `max_dim_px`, optional `contrast_factor` (used when `"contrast"` is in the pipeline)
 - **DWc mapping** – `assume_country_if_missing`, `strict_minimal_fields`, normalization toggles
 - **QC** – duplicate detection (`phash_threshold`), low-confidence flagging, top-fifth scan flag
 - **Processing** – `retry_limit` for failed specimens
@@ -109,6 +109,7 @@ Preprocessing steps are registered via `preprocess.register_preprocessor`. Confi
 ```toml
 [preprocess]
 pipeline   = ["grayscale", "deskew", "binarize", "resize"]
+binarize_method = "adaptive"
 max_dim_px = 4000
 contrast_factor = 1.5  # used when "contrast" is in the pipeline
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -6,12 +6,11 @@
 4. Populate mapping rules in `config/rules/dwc_rules.toml` – _medium_.
 5. Support full schema parsing from official Darwin Core and ABCD XSDs – _medium_.
 6. Add tests covering configurable GPT prompt templates – _easy_.
-7. Add adaptive thresholding step in preprocessing – _medium_.
-8. Integrate multilingual OCR models – _high_.
-9. Support GPU-accelerated inference for Tesseract – _medium_.
-10. Transition pipeline storage to an ORM – _medium_.
-11. Add audit trail for import steps with explicit user sign-off – _medium_.
-12. Version DwC-A export bundles with embedded manifest – _high_.
-13. Generate spreadsheet pivot table exports for data summaries – _low_.
-14. Expand procedural examples across docs – _low_.
-15. Implement locality cross-checks using Gazetteer API – _low_.
+7. Integrate multilingual OCR models – _high_.
+8. Support GPU-accelerated inference for Tesseract – _medium_.
+9. Transition pipeline storage to an ORM – _medium_.
+10. Add audit trail for import steps with explicit user sign-off – _medium_.
+11. Version DwC-A export bundles with embedded manifest – _high_.
+12. Generate spreadsheet pivot table exports for data summaries – _low_.
+13. Expand procedural examples across docs – _low_.
+14. Implement locality cross-checks using Gazetteer API – _low_.

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -30,7 +30,7 @@ steps = ["image_to_text", "text_to_dwc"]
 
 [preprocess]
 pipeline = ["grayscale", "deskew", "binarize", "resize"]
-binarize = "adaptive_sauvola"
+binarize_method = "adaptive"  # "otsu" or "adaptive"
 max_dim_px = 4000
 contrast_factor = 1.5  # used when "contrast" is in the pipeline
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,20 @@ to Darwin Core terms:
 steps = ["image_to_text", "text_to_dwc"]
 ```
 
+## Preprocessing settings
+
+Image cleanup steps live in the `[preprocess]` section. Use `pipeline` to list
+preprocessors and `binarize_method` to switch between global Otsu and adaptive
+Sauvola thresholding:
+
+```toml
+[preprocess]
+pipeline = ["grayscale", "deskew", "binarize", "resize"]
+binarize_method = "adaptive"  # or "otsu"
+max_dim_px = 4000
+contrast_factor = 1.5  # used when "contrast" is in the pipeline
+```
+
 ## Rules directory
 
 Mapping and normalisation rules live under [`../config/rules`](../config/rules).

--- a/docs/preprocessing_flows.md
+++ b/docs/preprocessing_flows.md
@@ -1,4 +1,4 @@
-# OCR Engine Preprocessing Flows
+# OCR engine preprocessing flows
 
 This document summarizes recommended preprocessing steps for each supported OCR engine. The steps correspond to functions in `preprocess` and can be composed via the `pipeline` list in the configuration file's `[preprocess]` section.
 
@@ -17,7 +17,7 @@ Apple's Vision framework handles color balance and skew internally, so additiona
 | `grayscale` | Remove color information                        | — |
 | `contrast`  | Enhance text/background separation              | `contrast_factor` 1.3–1.7 (default 1.5) |
 | `deskew`    | Correct rotation based on principal components  | — |
-| `binarize`  | Otsu threshold to isolate foreground            | — |
+| `binarize`  | Otsu or adaptive (Sauvola) threshold            | `binarize_method` "otsu" or "adaptive" |
 | `resize`    | Improve OCR accuracy at higher resolution       | `max_dim_px` 3000–4000 |
 
 This sequence yields high-quality input for Tesseract by maximizing contrast and text sharpness before recognition.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,6 @@ Secondary tasks cover medium and low priority items detailed below.
 
 | Feature | Priority | Timeline |
 | --- | --- | --- |
-| Add adaptive thresholding step in the [preprocessing flows](preprocessing_flows.md) | Medium | Q2 2025 |
 | Batch resize large images to accelerate OCR | Low | Q3 2025 |
 | Integrate multilingual OCR models for non-English labels | High | Q2 2025 |
 | Support GPU-accelerated inference for Tesseract | Medium | Q3 2025 |

--- a/preprocess/__init__.py
+++ b/preprocess/__init__.py
@@ -69,8 +69,48 @@ def _otsu_threshold(gray: np.ndarray) -> int:
     return threshold
 
 
-def binarize(image: Image.Image, method: str | bool = "otsu") -> Image.Image:
-    """Binarize an image using Otsu's threshold."""
+def _sauvola_threshold(gray: np.ndarray, window_size: int = 25, k: float = 0.2, r: int = 128) -> np.ndarray:
+    """Compute Sauvola threshold surface for ``gray`` image."""
+    pad = window_size // 2
+    padded = np.pad(gray, pad, mode="reflect")
+    integral = np.cumsum(np.cumsum(padded, axis=0), axis=1)
+    integral = np.pad(integral, ((1, 0), (1, 0)), mode="constant")
+    integral_sq = np.cumsum(np.cumsum(padded ** 2, axis=0), axis=1)
+    integral_sq = np.pad(integral_sq, ((1, 0), (1, 0)), mode="constant")
+    w = window_size
+    sum_ = (
+        integral[w:, w:] - integral[:-w, w:] - integral[w:, :-w] + integral[:-w, :-w]
+    )
+    sum_sq = (
+        integral_sq[w:, w:] - integral_sq[:-w, w:] - integral_sq[w:, :-w] + integral_sq[:-w, :-w]
+    )
+    area = w * w
+    mean = sum_ / area
+    variance = sum_sq / area - mean ** 2
+    std = np.sqrt(np.maximum(variance, 0))
+    return mean * (1 + k * (std / r - 1))
+
+
+def adaptive_threshold(image: Image.Image, window_size: int = 25, k: float = 0.2) -> Image.Image:
+    """Binarize an image using Sauvola's adaptive threshold."""
+    gray = np.array(image.convert("L"), dtype=float)
+    h, w = gray.shape
+    window_size = min(window_size, h, w)
+    if window_size % 2 == 0:
+        window_size -= 1
+    window_size = max(window_size, 3)
+    thresh = _sauvola_threshold(gray, window_size=window_size, k=k)
+    binary = (gray > thresh).astype(np.uint8) * 255
+    return Image.fromarray(binary)
+
+
+def binarize(image: Image.Image, method: str | bool = "otsu", **kwargs) -> Image.Image:
+    """Binarize ``image`` using the chosen ``method``."""
+    method_str = str(method).lower() if not isinstance(method, bool) else "otsu"
+    if method_str == "adaptive":
+        window = int(kwargs.get("window_size", 25))
+        k = float(kwargs.get("k", 0.2))
+        return adaptive_threshold(image, window, k)
     gray = np.array(image.convert("L"))
     thresh = _otsu_threshold(gray)
     binary = (gray > thresh).astype(np.uint8) * 255
@@ -109,7 +149,23 @@ def preprocess_image(path: Path, cfg: Dict[str, Any]) -> Path:
 
 register_preprocessor("grayscale", lambda img, cfg: grayscale(img))
 register_preprocessor("deskew", lambda img, cfg: deskew(img))
-register_preprocessor("binarize", lambda img, cfg: binarize(img))
+register_preprocessor(
+    "binarize",
+    lambda img, cfg: binarize(
+        img,
+        cfg.get("binarize_method", "otsu"),
+        window_size=cfg.get("adaptive_window_size"),
+        k=cfg.get("adaptive_k"),
+    ),
+)
+register_preprocessor(
+    "adaptive_threshold",
+    lambda img, cfg: adaptive_threshold(
+        img,
+        int(cfg.get("adaptive_window_size", 25)),
+        float(cfg.get("adaptive_k", 0.2)),
+    ),
+)
 
 
 def _contrast_step(img: Image.Image, cfg: Dict[str, Any]) -> Image.Image:
@@ -136,6 +192,7 @@ __all__ = [
     "grayscale",
     "deskew",
     "binarize",
+    "adaptive_threshold",
     "contrast",
     "resize",
     "preprocess_image",

--- a/preprocess/flows.py
+++ b/preprocess/flows.py
@@ -16,6 +16,7 @@ APPLE_VISION: Dict[str, Any] = {
 TESSERACT: Dict[str, Any] = {
     # Tesseract benefits from aggressive normalization and binarization.
     "pipeline": ["grayscale", "contrast", "deskew", "binarize", "resize"],
+    "binarize_method": "adaptive",
     # Contrast factor of 1.3–1.7 sharpens faint text without clipping.
     "contrast_factor": 1.5,
     # Resize so the longest edge is around 3000–4000 pixels.

--- a/tests/unit/test_preprocess.py
+++ b/tests/unit/test_preprocess.py
@@ -1,7 +1,7 @@
 import numpy as np
 from PIL import Image, ImageDraw
 
-from preprocess import grayscale, deskew, binarize, resize
+from preprocess import adaptive_threshold, grayscale, deskew, binarize, resize
 
 
 def test_grayscale_converts_to_l_mode():
@@ -14,6 +14,22 @@ def test_binarize_produces_binary_image():
     arr = np.tile(np.linspace(0, 255, 10, dtype=np.uint8), (10, 1))
     img = Image.fromarray(arr)
     binary = binarize(img)
+    uniq = np.unique(np.array(binary))
+    assert set(uniq).issubset({0, 255})
+
+
+def test_adaptive_threshold_produces_binary_image():
+    arr = np.tile(np.linspace(0, 255, 10, dtype=np.uint8), (10, 1))
+    img = Image.fromarray(arr)
+    binary = adaptive_threshold(img)
+    uniq = np.unique(np.array(binary))
+    assert set(uniq).issubset({0, 255})
+
+
+def test_binarize_adaptive_method():
+    arr = np.tile(np.linspace(0, 255, 10, dtype=np.uint8), (10, 1))
+    img = Image.fromarray(arr)
+    binary = binarize(img, method="adaptive")
     uniq = np.unique(np.array(binary))
     assert set(uniq).issubset({0, 255})
 


### PR DESCRIPTION
## Summary
- implement Sauvola-based `adaptive_threshold` preprocessor and expose method selection in `binarize`
- add adaptive threshold option to Tesseract flow and default config
- document preprocessing settings and update roadmap/TODO

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf811717dc832faa1d53dc150e766e