### PR TITLE
feat: configurable GBIF endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Added
 - ✨ adaptive threshold preprocessor with selectable Otsu or Sauvola binarization
+- :gear: configurable GBIF endpoint URLs
 
 ### Docs
 - 📝 document adaptive thresholding options in preprocessing and configuration guides
+- 📝 explain how to override GBIF endpoints in QC guide
 
 ## [0.1.3] - 2025-09-08 (0.1.3)
 

--- a/cli.py
+++ b/cli.py
@@ -8,6 +8,7 @@ from typing import Optional, Dict, Any, List
 import sys
 from importlib import resources
 from engines import dispatch, available_engines, get_fallback_policy
+from qc import gbif as gbif_module
 
 if sys.version_info >= (3, 11):
     import tomllib as tomli
@@ -81,6 +82,9 @@ def setup_run(
     if enabled_engines is not None:
         cfg.setdefault("ocr", {})["enabled_engines"] = list(enabled_engines)
     qc.TOP_FIFTH_PCT = cfg.get("qc", {}).get("top_fifth_scan_pct", qc.TOP_FIFTH_PCT)
+    gbif_module.configure(cfg)
+    qc.GBIF_SPECIES_MATCH_ENDPOINT = gbif_module.GBIF_SPECIES_MATCH_ENDPOINT
+    qc.GBIF_REVERSE_GEOCODE_ENDPOINT = gbif_module.GBIF_REVERSE_GEOCODE_ENDPOINT
     return cfg
 
 

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -45,6 +45,10 @@ parse_scientific_names = true
 normalize_spelling = true
 do_not_update_nomenclature = true
 
+[gbif]
+species_match_endpoint = "https://api.gbif.org/v1/species/match"
+reverse_geocode_endpoint = "https://api.gbif.org/v1/geocode/reverse"
+
 [qc]
 dupes = ["catalog","sha256","phash"]
 phash_threshold = 10

--- a/docs/qc.md
+++ b/docs/qc.md
@@ -7,3 +7,18 @@ python review.py --tui path/to/candidates.db specimen.jpg
 ```
 
 Use the arrow keys to highlight a candidate and press Enter to confirm. The chosen value is persisted through [`io_utils.candidates.record_decision`](../io_utils/candidates.py). If the terminal cannot display images, a text placeholder is shown instead.
+
+## Override GBIF endpoints
+
+The default [GBIF](https://www.gbif.org/) URLs used for taxonomy and locality
+checks can be replaced via the configuration file. Add a `[gbif]` section to
+your config and supply alternative endpoints:
+
+```toml
+[gbif]
+species_match_endpoint = "https://example.org/species"
+reverse_geocode_endpoint = "https://example.org/geocode"
+```
+
+These values override the defaults from `config.default.toml` and are applied
+when running any QC-related commands.

--- a/qc/gbif.py
+++ b/qc/gbif.py
@@ -10,10 +10,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-# GBIF API endpoints used for validation
-# TODO: Move API endpoints into configuration.
+# GBIF API endpoints used for validation. Defaults match the public API but can
+# be overridden via configuration.
 GBIF_SPECIES_MATCH_ENDPOINT = "https://api.gbif.org/v1/species/match"
 GBIF_REVERSE_GEOCODE_ENDPOINT = "https://api.gbif.org/v1/geocode/reverse"
+
+
+def configure(cfg: Dict[str, Any]) -> None:
+    """Configure GBIF endpoints from the application configuration."""
+
+    gbif_cfg = cfg.get("gbif", {})
+    global GBIF_SPECIES_MATCH_ENDPOINT, GBIF_REVERSE_GEOCODE_ENDPOINT
+    GBIF_SPECIES_MATCH_ENDPOINT = gbif_cfg.get(
+        "species_match_endpoint", GBIF_SPECIES_MATCH_ENDPOINT
+    )
+    GBIF_REVERSE_GEOCODE_ENDPOINT = gbif_cfg.get(
+        "reverse_geocode_endpoint", GBIF_REVERSE_GEOCODE_ENDPOINT
+    )
 
 # Mapping of local record fields to GBIF query parameters
 TAXONOMY_QUERY_MAP: Dict[str, str] = {
@@ -106,4 +119,5 @@ __all__ = [
     "LOCALITY_QUERY_MAP",
     "TAXONOMY_FIELDS",
     "LOCALITY_FIELDS",
+    "configure",
 ]

--- a/tests/unit/test_gbif.py
+++ b/tests/unit/test_gbif.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import qc
+from cli import setup_run
+
+
+def test_custom_gbif_endpoints(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        """
+[gbif]
+species_match_endpoint = "https://example.org/species"
+reverse_geocode_endpoint = "https://example.org/geocode"
+"""
+    )
+
+    setup_run(tmp_path, cfg_path, None)
+
+    assert qc.GBIF_SPECIES_MATCH_ENDPOINT == "https://example.org/species"
+    assert qc.GBIF_REVERSE_GEOCODE_ENDPOINT == "https://example.org/geocode"


### PR DESCRIPTION
## Summary
- allow overriding GBIF API endpoints via configuration
- document how to customize GBIF URLs
- test that custom endpoints are applied

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf89361998832fbf9f8d000ac25bfc