### PR TITLE
Add mapping and vocabulary rules with tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,9 @@
 1. Implement GBIF taxonomy and locality verification for QC (context: `qc/gbif.py`) – _medium_.
 2. Move GBIF API endpoints into configuration files – _easy_.
 3. Expand vocabulary normalisation entries in `config/rules/vocab.toml` – _easy_.
+   - Basis of record and sex mappings have initial coverage.
 4. Populate mapping rules in `config/rules/dwc_rules.toml` – _medium_.
+   - Collector and collection date aliases added; extend for other fields.
 5. Support full schema parsing from official Darwin Core and ABCD XSDs – _medium_.
 6. Add tests covering configurable GPT prompt templates – _easy_.
 7. Integrate multilingual OCR models – _high_.

--- a/config/rules/dwc_rules.toml
+++ b/config/rules/dwc_rules.toml
@@ -1,2 +1,8 @@
 # Mapping rules from raw OCR output to Darwin Core terms.
 # Use this file to declare regex or lookup substitutions.
+
+# Representative field aliases. Values point to Darwin Core terms
+# as catalogued by GBIF's Darwin Core Quick Reference Guide.
+# https://dwc.tdwg.org/terms/
+collector = "recordedBy"  # https://rs.gbif.org/terms/1.0/recordedBy
+"collection date" = "eventDate"  # https://rs.gbif.org/terms/1.0/eventDate

--- a/config/rules/vocab.toml
+++ b/config/rules/vocab.toml
@@ -1,2 +1,14 @@
 # Vocabulary normalisation tables.
 # Populate with mappings such as "Herbarium sheet" = "preservedSpecimen".
+
+[basisOfRecord]
+# GBIF Basis of Record vocabulary
+# https://rs.gbif.org/vocabulary/dwc/basis_of_record.xml
+"herbarium sheet" = "PreservedSpecimen"
+photo = "StillImage"
+
+[sex]
+# GBIF Sex vocabulary
+# https://rs.gbif.org/vocabulary/gbif/sex.xml
+m = "male"
+f = "female"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,9 +34,11 @@ contrast_factor = 1.5  # used when "contrast" is in the pipeline
 
 Mapping and normalisation rules live under [`../config/rules`](../config/rules).
 
-- [`dwc_rules.toml`](../config/rules/dwc_rules.toml) – transformation rules for raw OCR fields.
+- [`dwc_rules.toml`](../config/rules/dwc_rules.toml) – transformation rules for raw OCR fields
+  such as `collector` → `recordedBy` and `collection date` → `eventDate`.
 - [`institutions.toml`](../config/rules/institutions.toml) – maps legacy institution codes to canonical values.
-- [`vocab.toml`](../config/rules/vocab.toml) – vocabulary normalisation tables.
+- [`vocab.toml`](../config/rules/vocab.toml) – vocabulary normalisation tables including
+  `basisOfRecord` and `sex` mappings based on GBIF vocabularies.
 
 These files support the mapping phase and are independent from preprocessing and OCR
 artifacts stored in the pipeline database.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,6 +25,9 @@ Secondary tasks cover medium and low priority items detailed below.
 | Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml` | Medium | Q2 2025 |
 | Auto-generate Darwin Core term mappings from external XSD | Low | Q4 2025 |
 
+Initial rules now cover common aliases such as `collector` and `collection date`
+and normalise `basisOfRecord` values according to GBIF vocabularies.
+
 ## Quality control
 
 | Feature | Priority | Timeline |

--- a/dwc/__init__.py
+++ b/dwc/__init__.py
@@ -1,6 +1,6 @@
 from .schema import DwcRecord, DWC_TERMS, configure_terms, resolve_term
 from .mapper import map_ocr_to_dwc
-from .normalize import normalize_institution, normalize_vocab
+from .normalize import normalize_institution, normalize_vocab, normalize_field_name
 from .validators import (
     validate,
     validate_minimal_fields,
@@ -16,6 +16,7 @@ __all__ = [
     "map_ocr_to_dwc",
     "normalize_institution",
     "normalize_vocab",
+    "normalize_field_name",
     "validate",
     "validate_minimal_fields",
     "validate_event_date",

--- a/dwc/mapper.py
+++ b/dwc/mapper.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Iterable
 
 from .schema import DwcRecord, resolve_term
 from . import schema
-from .normalize import normalize_institution, normalize_vocab
+from .normalize import normalize_field_name, normalize_institution, normalize_vocab
 from .validators import validate
 
 
@@ -23,7 +23,8 @@ def map_ocr_to_dwc(ocr_output: Dict[str, Any], minimal_fields: Iterable[str] = (
 
     data: Dict[str, Any] = {}
     for raw_key, value in ocr_output.items():
-        term = resolve_term(str(raw_key))
+        field = normalize_field_name(str(raw_key))
+        term = resolve_term(field)
         if term in schema.DWC_TERMS:
             data[term] = value
 

--- a/dwc/normalize.py
+++ b/dwc/normalize.py
@@ -41,6 +41,21 @@ def normalize_institution(value: str) -> str:
     return mapping.get(value.lower(), value)
 
 
+def normalize_field_name(name: str) -> str:
+    """Return the canonical Darwin Core field name for ``name``.
+
+    Mappings are defined in ``config/rules/dwc_rules.toml`` where keys
+    correspond to raw OCR field names. Values reference Darwin Core
+    terms from the GBIF vocabulary.
+    """
+
+    if not name:
+        return name
+    rules = _load_rules("dwc_rules")
+    mapping = {k.lower(): v for k, v in rules.items()}
+    return mapping.get(name.lower(), name)
+
+
 def normalize_vocab(value: str, vocab: str) -> str:
     """Normalise ``value`` based on the vocabulary ``vocab``.
 

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -1,0 +1,17 @@
+from dwc import map_ocr_to_dwc, normalize_vocab
+
+
+def test_mapping_rules_and_vocab_normalization() -> None:
+    ocr_output = {
+        "collector": "A. Botanist",
+        "collection date": "2024-05-01",
+        "basisOfRecord": "herbarium sheet",
+    }
+    record = map_ocr_to_dwc(ocr_output)
+    assert record.recordedBy == "A. Botanist"
+    assert record.eventDate == "2024-05-01"
+    assert record.basisOfRecord == "PreservedSpecimen"
+
+
+def test_sex_vocab_normalization() -> None:
+    assert normalize_vocab("f", "sex") == "female"


### PR DESCRIPTION
## Summary
- map common OCR field aliases like `collector` and `collection date` to Darwin Core terms
- normalise `basisOfRecord` and `sex` values using GBIF vocabularies
- document rule coverage and test mapping/normalisation

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf92911248832f9aec3de0f73cda6f