### PR TITLE
Add DwC mapping and vocabulary rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - ✨ adaptive threshold preprocessor with selectable Otsu or Sauvola binarization
 - ✨ configurable GBIF endpoints via `[qc.gbif]` config section
+- ✨ core Darwin Core field mappings and controlled vocabularies
 
 ### Docs
 - 📝 document adaptive thresholding options in preprocessing and configuration guides

--- a/TODO.md
+++ b/TODO.md
@@ -2,15 +2,13 @@
 
 1. Implement GBIF taxonomy and locality verification for QC (context: `qc/gbif.py`) – _medium_.
 2. Move GBIF API endpoints into configuration files – _easy_.
-3. Expand vocabulary normalisation entries in `config/rules/vocab.toml` – _easy_.
-4. Populate mapping rules in `config/rules/dwc_rules.toml` – _medium_.
-5. Support full schema parsing from official Darwin Core and ABCD XSDs – _medium_.
-6. Add tests covering configurable GPT prompt templates – _easy_.
-7. Integrate multilingual OCR models – _high_.
-8. Support GPU-accelerated inference for Tesseract – _medium_.
-9. Transition pipeline storage to an ORM – _medium_.
-10. Add audit trail for import steps with explicit user sign-off – _medium_.
-11. Version DwC-A export bundles with embedded manifest – _high_.
-12. Generate spreadsheet pivot table exports for data summaries – _low_.
-13. Expand procedural examples across docs – _low_.
-14. Implement locality cross-checks using Gazetteer API – _low_.
+3. Support full schema parsing from official Darwin Core and ABCD XSDs – _medium_.
+4. Add tests covering configurable GPT prompt templates – _easy_.
+5. Integrate multilingual OCR models – _high_.
+6. Support GPU-accelerated inference for Tesseract – _medium_.
+7. Transition pipeline storage to an ORM – _medium_.
+8. Add audit trail for import steps with explicit user sign-off – _medium_.
+9. Version DwC-A export bundles with embedded manifest – _high_.
+10. Generate spreadsheet pivot table exports for data summaries – _low_.
+11. Expand procedural examples across docs – _low_.
+12. Implement locality cross-checks using Gazetteer API – _low_.

--- a/config/README.md
+++ b/config/README.md
@@ -9,3 +9,4 @@ application.
 - `schemas/` – Darwin Core and ABCD schema definitions used to populate field
   lists.
 - `rules/` – mapping and normalisation tables applied during data cleaning.
+  See [mapping and vocabulary](../docs/mapping_and_vocabulary.md) for details.

--- a/config/rules/dwc_rules.toml
+++ b/config/rules/dwc_rules.toml
@@ -1,2 +1,16 @@
 # Mapping rules from raw OCR output to Darwin Core terms.
 # Use this file to declare regex or lookup substitutions.
+
+# Field name aliases mapped to Darwin Core terms.
+[fields]
+# Common header printed on barcode labels
+barcode = "catalogNumber"
+# Collector name appearing on labels
+collector = "recordedBy"
+# Verbatim date strings found on sheets
+"date collected" = "eventDate"
+# Geographic annotations
+country = "country"
+province = "stateProvince"
+locality = "locality"
+"scientific name" = "scientificName"

--- a/config/rules/vocab.toml
+++ b/config/rules/vocab.toml
@@ -1,2 +1,17 @@
 # Vocabulary normalisation tables.
-# Populate with mappings such as "Herbarium sheet" = "preservedSpecimen".
+# Populate with mappings such as "Herbarium sheet" = "PreservedSpecimen".
+
+[basisOfRecord]
+# Map common phrases to Darwin Core controlled terms
+"herbarium sheet" = "PreservedSpecimen"
+"preserved specimen" = "PreservedSpecimen"
+"fossil" = "FossilSpecimen"
+"observation" = "HumanObservation"
+
+[typeStatus]
+# Normalise type citations
+Holotype = "holotype"
+Isotype = "isotype"
+Paratype = "paratype"
+Lectotype = "lectotype"
+Neotype = "neotype"

--- a/docs/mapping_and_vocabulary.md
+++ b/docs/mapping_and_vocabulary.md
@@ -1,0 +1,10 @@
+# Mapping and vocabulary
+
+During the mapping phase, OCR output is normalised before loading into the
+primary DwC+ABCD database. Field aliases are resolved using
+[dwc_rules.toml](../config/rules/dwc_rules.toml), while controlled vocabulary
+values such as `basisOfRecord` and `typeStatus` are defined in
+[vocab.toml](../config/rules/vocab.toml).
+
+See the [configuration README](../config/README.md) for an overview of all
+available rule files.

--- a/dwc/mapper.py
+++ b/dwc/mapper.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Iterable
 
 from .schema import DwcRecord, resolve_term
 from . import schema
-from .normalize import normalize_institution, normalize_vocab
+from .normalize import normalize_institution, normalize_vocab, _load_rules
 from .validators import validate
 
 
@@ -22,10 +22,15 @@ def map_ocr_to_dwc(ocr_output: Dict[str, Any], minimal_fields: Iterable[str] = (
     """
 
     data: Dict[str, Any] = {}
+    rules = {k.lower(): v for k, v in _load_rules("dwc_rules").get("fields", {}).items()}
     for raw_key, value in ocr_output.items():
         term = resolve_term(str(raw_key))
         if term in schema.DWC_TERMS:
             data[term] = value
+            continue
+        mapped = rules.get(str(raw_key).lower())
+        if mapped in schema.DWC_TERMS:
+            data[mapped] = value
 
     # Normalise institution codes
     for field in ("institutionCode", "ownerInstitutionCode"):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from cli import load_config
+from dwc import normalize_vocab
 
 
 def test_load_config_merge(tmp_path: Path) -> None:
@@ -19,3 +20,8 @@ model = "gpt-test"
     assert cfg["gpt"]["model"] == "gpt-test"
     # default from base config remains
     assert cfg["ocr"]["allow_gpt"] is True
+
+
+def test_normalize_vocab_rules() -> None:
+    assert normalize_vocab("herbarium sheet", "basisOfRecord") == "PreservedSpecimen"
+    assert normalize_vocab("Holotype", "typeStatus") == "holotype"

--- a/tests/unit/test_qc.py
+++ b/tests/unit/test_qc.py
@@ -10,6 +10,7 @@ from qc.gbif import (
     DEFAULT_SPECIES_MATCH_ENDPOINT,
     GbifLookup,
 )
+from dwc.mapper import map_ocr_to_dwc
 
 
 def test_detect_duplicates_hash_collision():
@@ -58,3 +59,18 @@ reverse_geocode_endpoint = "https://example.org/reverse"
     gbif = GbifLookup.from_config(cfg)
     assert gbif.species_match_endpoint == "https://example.org/species"
     assert gbif.reverse_geocode_endpoint == "https://example.org/reverse"
+
+
+def test_map_ocr_to_dwc_rules() -> None:
+    record = map_ocr_to_dwc(
+        {
+            "collector": "Jane Doe",
+            "date collected": "2025-09-01",
+            "barcode": "ABC123",
+            "basisOfRecord": "herbarium sheet",
+        }
+    )
+    assert record.recordedBy == "Jane Doe"
+    assert record.eventDate == "2025-09-01"
+    assert record.catalogNumber == "ABC123"
+    assert record.basisOfRecord == "PreservedSpecimen"


### PR DESCRIPTION
## Summary
- map common OCR field aliases to core Darwin Core terms
- normalize basisOfRecord and typeStatus via controlled vocabularies
- document mapping and vocabulary rules with config cross-links

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf929c6338832fa512e7099180a264