### PR TITLE
Add DwC mapping and vocabulary rules

### DIFF
--- a/config/schemas/abcd.xsd
+++ b/config/schemas/abcd.xsd
@@ -19,6 +19,7 @@
   <xs:element name="identificationRemarks" type="xs:string"/>
   <xs:element name="identificationReferences" type="xs:string"/>
   <xs:element name="identificationVerificationStatus" type="xs:string"/>
+  <xs:element name="typeStatus" type="xs:string"/>
   <xs:element name="associatedOccurrences" type="xs:string"/>
   <xs:element name="occurrenceRemarks" type="xs:string"/>
   <xs:element name="dynamicProperties" type="xs:string"/>

--- a/dwc/mapper.py
+++ b/dwc/mapper.py
@@ -38,7 +38,7 @@ def map_ocr_to_dwc(ocr_output: Dict[str, Any], minimal_fields: Iterable[str] = (
             data[field] = normalize_institution(str(data[field]))
 
     # Normalise vocabulary-based terms
-    vocab_terms = ["basisOfRecord"]
+    vocab_terms = ["basisOfRecord", "typeStatus"]
     for field in vocab_terms:
         if field in data and data[field]:
             data[field] = normalize_vocab(str(data[field]), field)

--- a/dwc/schema.py
+++ b/dwc/schema.py
@@ -119,6 +119,7 @@ class DwcRecord(BaseModel):
     identificationRemarks: Optional[str] = None
     identificationReferences: Optional[str] = None
     identificationVerificationStatus: Optional[str] = None
+    typeStatus: Optional[str] = None
     associatedOccurrences: Optional[str] = None
     occurrenceRemarks: Optional[str] = None
     dynamicProperties: Optional[str] = None

--- a/tests/unit/test_qc.py
+++ b/tests/unit/test_qc.py
@@ -68,9 +68,11 @@ def test_map_ocr_to_dwc_rules() -> None:
             "date collected": "2025-09-01",
             "barcode": "ABC123",
             "basisOfRecord": "herbarium sheet",
+            "typeStatus": "Holotype",
         }
     )
     assert record.recordedBy == "Jane Doe"
     assert record.eventDate == "2025-09-01"
     assert record.catalogNumber == "ABC123"
     assert record.basisOfRecord == "PreservedSpecimen"
+    assert record.typeStatus == "holotype"


### PR DESCRIPTION
## Summary
- normalise `typeStatus` using shared vocabulary rules
- include `typeStatus` in schema and mapping tests

## Testing
- `ruff check . --fix`
- `ruff check dwc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf987f66b8832faaa8e2a6c77fff11