### PR TITLE
🐛 Normalize typeStatus vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - ✨ configurable GBIF endpoints via `[qc.gbif]` config section
 - ✨ core Darwin Core field mappings and controlled vocabularies
 
+### Fixed
+- 🐛 normalize `typeStatus` citations to lowercase using vocabulary rules
+
 ### Docs
 - 📝 document adaptive thresholding options in preprocessing and configuration guides
 - 📝 document GBIF endpoint overrides in QC and configuration guides


### PR DESCRIPTION
## Summary
- Normalize `typeStatus` values using shared vocabulary and include the term in Darwin Core schemas.
- Document `typeStatus` normalization in the changelog.

## Testing
- `ruff check . --fix`
- `ruff check dwc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf9aa308f8832f9e48387fc1f0b0b9