### PR TITLE
Add configurable Darwin Core term mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - ✨ adaptive threshold preprocessor with selectable Otsu or Sauvola binarization
 - ✨ configurable GBIF endpoints via `[qc.gbif]` config section
 - ✨ core Darwin Core field mappings and controlled vocabularies
+- ✨ load custom Darwin Core term mappings via `[dwc.custom]` config section
 
 ### Fixed
 - 🐛 normalize `typeStatus` citations to lowercase using vocabulary rules
@@ -13,6 +14,7 @@
 ### Docs
 - 📝 document adaptive thresholding options in preprocessing and configuration guides
 - 📝 document GBIF endpoint overrides in QC and configuration guides
+- 📝 document custom term mappings and vocabulary examples
 
 ## [0.1.3] - 2025-09-08 (0.1.3)
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,5 +10,4 @@
 8. Add audit trail for import steps with explicit user sign-off – _medium_.
 9. Version DwC-A export bundles with embedded manifest – _high_.
 10. Generate spreadsheet pivot table exports for data summaries – _low_.
-11. Expand procedural examples across docs – _low_.
-12. Implement locality cross-checks using Gazetteer API – _low_.
+11. Implement locality cross-checks using Gazetteer API – _low_.

--- a/cli.py
+++ b/cli.py
@@ -36,7 +36,7 @@ from io_utils.database import (
     record_failure,
     upsert_processing_state,
 )
-from dwc import configure_terms
+from dwc import configure_terms, configure_mappings
 from engines.errors import EngineError
 from preprocess import preprocess_image
 
@@ -78,6 +78,7 @@ def setup_run(
         schema_files.append(path)
     if schema_files:
         configure_terms(schema_files)
+    configure_mappings(dwc_cfg.get("custom", {}))
     if enabled_engines is not None:
         cfg.setdefault("ocr", {})["enabled_engines"] = list(enabled_engines)
     qc.TOP_FIFTH_PCT = cfg.get("qc", {}).get("top_fifth_scan_pct", qc.TOP_FIFTH_PCT)

--- a/config/README.md
+++ b/config/README.md
@@ -10,3 +10,13 @@ application.
   lists.
 - `rules/` – mapping and normalisation tables applied during data cleaning.
   See [mapping and vocabulary](../docs/mapping_and_vocabulary.md) for details.
+
+## Custom term mappings
+
+Override built-in field aliases by adding a `[dwc.custom]` section to your
+configuration. Each key maps a raw field name to a Darwin Core term:
+
+```toml
+[dwc.custom]
+barcode = "catalogNumber"
+```

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -45,6 +45,9 @@ parse_scientific_names = true
 normalize_spelling = true
 do_not_update_nomenclature = true
 
+[dwc.custom]
+# example = "catalogNumber"  # raw_field = "dwc_term"
+
 [qc]
 dupes = ["catalog","sha256","phash"]
 phash_threshold = 10

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,19 @@ Mapping and normalisation rules live under [`../config/rules`](../config/rules).
 These files support the mapping phase and are independent from preprocessing and OCR
 artifacts stored in the pipeline database.
 
+## Custom term mappings
+
+Define project-specific field aliases with `[dwc.custom]` in the configuration.
+Keys are raw field names and values are Darwin Core terms:
+
+```toml
+[dwc.custom]
+sheetNumber = "catalogNumber"
+```
+
+Custom mappings override entries in
+[`dwc_rules.toml`](../config/rules/dwc_rules.toml).
+
 ## GPT prompts and secrets
 
 Prompt templates for the GPT engine reside in

--- a/docs/mapping_and_vocabulary.md
+++ b/docs/mapping_and_vocabulary.md
@@ -8,3 +8,37 @@ values such as `basisOfRecord` and `typeStatus` are defined in
 
 See the [configuration README](../config/README.md) for an overview of all
 available rule files.
+
+## Field mapping example
+
+Create a custom alias for `barcode` by adding a `[dwc.custom]` section to the
+configuration:
+
+```toml
+[dwc.custom]
+barcode = "catalogNumber"
+```
+
+With this configuration, the mapping function converts OCR output:
+
+```python
+from dwc import configure_mappings, map_ocr_to_dwc
+
+configure_mappings({"barcode": "catalogNumber"})
+record = map_ocr_to_dwc({"barcode": "ABC123"})
+```
+
+The resulting `record.catalogNumber` is `"ABC123"`.
+
+## Vocabulary normalisation example
+
+Controlled terms such as `basisOfRecord` are harmonised via
+[`vocab.toml`](../config/rules/vocab.toml):
+
+```python
+from dwc import normalize_vocab
+
+normalize_vocab("herbarium sheet", "basisOfRecord")
+```
+
+This call returns `"PreservedSpecimen"`.

--- a/dwc/__init__.py
+++ b/dwc/__init__.py
@@ -1,5 +1,5 @@
 from .schema import DwcRecord, DWC_TERMS, configure_terms, resolve_term
-from .mapper import map_ocr_to_dwc
+from .mapper import map_ocr_to_dwc, configure_mappings
 from .normalize import normalize_institution, normalize_vocab
 from .validators import (
     validate,
@@ -12,6 +12,7 @@ __all__ = [
     "DwcRecord",
     "DWC_TERMS",
     "configure_terms",
+    "configure_mappings",
     "resolve_term",
     "map_ocr_to_dwc",
     "normalize_institution",

--- a/dwc/mapper.py
+++ b/dwc/mapper.py
@@ -8,6 +8,16 @@ from .normalize import normalize_institution, normalize_vocab, _load_rules
 from .validators import validate
 
 
+_CUSTOM_MAPPINGS: Dict[str, str] = {}
+
+
+def configure_mappings(mapping: Dict[str, str]) -> None:
+    """Register custom field mappings from the configuration."""
+    _CUSTOM_MAPPINGS.clear()
+    for raw, term in mapping.items():
+        _CUSTOM_MAPPINGS[raw.lower()] = term
+
+
 def map_ocr_to_dwc(ocr_output: Dict[str, Any], minimal_fields: Iterable[str] = ()) -> DwcRecord:
     """Translate OCR output into a :class:`DwcRecord`.
 
@@ -23,6 +33,7 @@ def map_ocr_to_dwc(ocr_output: Dict[str, Any], minimal_fields: Iterable[str] = (
 
     data: Dict[str, Any] = {}
     rules = {k.lower(): v for k, v in _load_rules("dwc_rules").get("fields", {}).items()}
+    rules.update(_CUSTOM_MAPPINGS)
     for raw_key, value in ocr_output.items():
         term = resolve_term(str(raw_key))
         if term in schema.DWC_TERMS:

--- a/tests/unit/test_candidates.py
+++ b/tests/unit/test_candidates.py
@@ -13,6 +13,7 @@ from io_utils.candidates import (
     fetch_decision,
     import_decisions,
 )
+from dwc import configure_mappings, map_ocr_to_dwc
 
 
 def test_candidate_roundtrip(tmp_path: Path) -> None:
@@ -99,3 +100,10 @@ def test_import_decisions_conflict(tmp_path: Path) -> None:
     dest.commit()
     with pytest.raises(ValueError):
         import_decisions(dest, src)
+
+
+def test_map_ocr_with_custom_mapping() -> None:
+    configure_mappings({"sheet": "catalogNumber"})
+    record = map_ocr_to_dwc({"sheet": "99"})
+    assert record.catalogNumber == "99"
+    configure_mappings({})

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,6 +5,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from cli import load_config
 from dwc import normalize_vocab
+from dwc import configure_mappings, map_ocr_to_dwc
 
 
 def test_load_config_merge(tmp_path: Path) -> None:
@@ -25,3 +26,16 @@ model = "gpt-test"
 def test_normalize_vocab_rules() -> None:
     assert normalize_vocab("herbarium sheet", "basisOfRecord") == "PreservedSpecimen"
     assert normalize_vocab("Holotype", "typeStatus") == "holotype"
+
+
+def test_custom_mappings_from_config(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text("""
+[dwc.custom]
+barcode = "catalogNumber"
+""")
+    cfg = load_config(cfg_path)
+    configure_mappings(cfg["dwc"]["custom"])
+    record = map_ocr_to_dwc({"barcode": "X"})
+    assert record.catalogNumber == "X"
+    configure_mappings({})


### PR DESCRIPTION
## Summary
- allow custom field aliases via `[dwc.custom]` configuration and `configure_mappings`
- document custom mapping usage with examples
- test custom mappings and update default config template

## Testing
- `ruff check . --fix`
- `ruff .` *(fails: unrecognized subcommand)*
- `ruff check .`
- `ruff dwc` *(fails: unrecognized subcommand)*
- `ruff check dwc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfa39c72e8832fb6f688d41c37dcbc