### PR TITLE
✨ add manifest and versioned DwC-A exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - ✨ configurable GBIF endpoints via `[qc.gbif]` config section
 - ✨ core Darwin Core field mappings and controlled vocabularies
 - ✨ load custom Darwin Core term mappings via `[dwc.custom]` config section
+- ✨ manifest metadata and versioned DwC-A exports
 
 ### Fixed
 - 🐛 normalize `typeStatus` citations to lowercase using vocabulary rules
@@ -15,6 +16,7 @@
 - 📝 document adaptive thresholding options in preprocessing and configuration guides
 - 📝 document GBIF endpoint overrides in QC and configuration guides
 - 📝 document custom term mappings and vocabulary examples
+- 📝 describe export versioning and manifest scheme
 
 ## [0.1.3] - 2025-09-08 (0.1.3)
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,5 @@
 6. Support GPU-accelerated inference for Tesseract – _medium_.
 7. Transition pipeline storage to an ORM – _medium_.
 8. Add audit trail for import steps with explicit user sign-off – _medium_.
-9. Version DwC-A export bundles with embedded manifest – _high_.
-10. Generate spreadsheet pivot table exports for data summaries – _low_.
-11. Implement locality cross-checks using Gazetteer API – _low_.
+9. Generate spreadsheet pivot table exports for data summaries – _low_.
+10. Implement locality cross-checks using Gazetteer API – _low_.

--- a/docs/export_review.md
+++ b/docs/export_review.md
@@ -1,0 +1,7 @@
+# Export review
+
+## Versioning scheme
+
+DwC-A exports are written under `./output/` using a version tag. When `compress=True` the archive is named `dwca-<version>.zip`; otherwise sidecar files are written directly to the directory. By default `<version>` is the current UTC timestamp, but a semantic version string may be supplied.
+
+Each export also includes a `manifest.json` containing the timestamp, commit hash, and any filters applied during export so that results can be reproduced.

--- a/dwc/archive.py
+++ b/dwc/archive.py
@@ -9,11 +9,14 @@ form a complete Darwin Core Archive (DwC-A).
 
 from __future__ import annotations
 
+import json
+import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
-from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
-from zipfile import ZipFile, ZIP_DEFLATED
-from typing import Dict
+from xml.etree.ElementTree import Element, SubElement, tostring
+from zipfile import ZIP_DEFLATED, ZipFile
+from typing import Any, Dict, Optional
 
 from .schema import DWC_TERMS
 from io_utils.write import IDENT_HISTORY_COLUMNS
@@ -103,16 +106,41 @@ def build_meta_xml(output_dir: Path) -> Path:
     return meta_path
 
 
-def create_archive(output_dir: Path, *, compress: bool = False) -> Path:
-    """Ensure DwC-A sidecar files exist and optionally create a ZIP archive.
+def _write_manifest(output_dir: Path, filters: Optional[Dict[str, Any]] = None) -> Path:
+    """Write a manifest with timestamp, commit hash, and filters."""
+
+    manifest = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "commit": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip(),
+        "filters": filters or {},
+    }
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return manifest_path
+
+
+def create_archive(
+    output_dir: Path,
+    *,
+    compress: bool = False,
+    filters: Optional[Dict[str, Any]] = None,
+    version: Optional[str] = None,
+) -> Path:
+    """Ensure DwC-A sidecar files exist and optionally create a versioned ZIP archive.
 
     Parameters
     ----------
     output_dir:
         Directory containing DwC CSV exports.
     compress:
-        If ``True``, a ``dwca.zip`` file will be created in ``output_dir``
-        containing the CSV files and ``meta.xml``.
+        If ``True``, a ``dwca-<version>.zip`` file will be created in ``output_dir``
+        containing the CSV files, ``meta.xml``, and ``manifest.json``.
+    filters:
+        Filter criteria applied during export.
+    version:
+        Semantic version or timestamp tag to use for naming the ZIP archive.
 
     Returns
     -------
@@ -121,12 +149,19 @@ def create_archive(output_dir: Path, *, compress: bool = False) -> Path:
     """
 
     meta_path = build_meta_xml(output_dir)
+    _write_manifest(output_dir, filters)
     if not compress:
         return meta_path
 
-    archive_path = output_dir / "dwca.zip"
+    version = version or datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    archive_path = output_dir / f"dwca-{version}.zip"
     with ZipFile(archive_path, "w", ZIP_DEFLATED) as zf:
-        for name in ["occurrence.csv", "identification_history.csv", "meta.xml"]:
+        for name in [
+            "occurrence.csv",
+            "identification_history.csv",
+            "meta.xml",
+            "manifest.json",
+        ]:
             file_path = output_dir / name
             if file_path.exists():
                 zf.write(file_path, arcname=name)

--- a/tests/integration/test_archive.py
+++ b/tests/integration/test_archive.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import xml.etree.ElementTree as ET
 import zipfile
 
@@ -18,7 +19,7 @@ def _prepare_csvs(output_dir: Path) -> None:
 
 def test_meta_xml_written(tmp_path: Path) -> None:
     _prepare_csvs(tmp_path)
-    create_archive(tmp_path, compress=False)
+    create_archive(tmp_path, compress=False, filters={"country": "Canada"})
     meta_path = tmp_path / "meta.xml"
     assert meta_path.exists()
 
@@ -34,12 +35,24 @@ def test_meta_xml_written(tmp_path: Path) -> None:
     ext_fields = ext.findall("dwc:field", ns)
     assert len(ext_fields) == len(IDENT_HISTORY_COLUMNS)
 
+    manifest_path = tmp_path / "manifest.json"
+    assert manifest_path.exists()
+    data = json.loads(manifest_path.read_text())
+    assert data["filters"] == {"country": "Canada"}
+    assert "timestamp" in data
+    assert "commit" in data
+
 
 def test_zip_archive_contains_required_files(tmp_path: Path) -> None:
     _prepare_csvs(tmp_path)
-    archive_path = create_archive(tmp_path, compress=True)
-    assert archive_path.exists()
+    archive_path = create_archive(tmp_path, compress=True, version="v1")
+    assert archive_path.name == "dwca-v1.zip"
 
     with zipfile.ZipFile(archive_path) as zf:
         names = set(zf.namelist())
-        assert {"occurrence.csv", "identification_history.csv", "meta.xml"} <= names
+        assert {
+            "occurrence.csv",
+            "identification_history.csv",
+            "meta.xml",
+            "manifest.json",
+        } <= names


### PR DESCRIPTION
## Summary
- embed manifest.json with timestamp, commit hash, and filters in Darwin Core exports
- version DwC-A zip names to include semantic or timestamp tags
- document export versioning scheme

## Testing
- `ruff check . --fix`
- `ruff check dwc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfacd3e2b0832f8bd82c3564238190