### PR TITLE
Add manifest and semantic versioning to DwC archive exports

### DIFF
--- a/dwc/archive.py
+++ b/dwc/archive.py
@@ -51,10 +51,13 @@ SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
 def build_manifest(filters: Dict[str, Any] | None = None) -> Dict[str, Any]:
     """Return run metadata for archive exports."""
-
-    commit = (
-        subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    )
+    commit = "unknown"
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
     timestamp = datetime.now(timezone.utc).isoformat()
     return {
         "timestamp": timestamp,

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -1,0 +1,17 @@
+import subprocess
+import pytest
+
+from dwc import archive
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [subprocess.CalledProcessError(1, "git"), FileNotFoundError()],
+)
+def test_build_manifest_handles_missing_git(monkeypatch, exception):
+    def _raise(*args, **kwargs):
+        raise exception
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    manifest = archive.build_manifest()
+    assert manifest["commit"] == "unknown"


### PR DESCRIPTION
## Summary
- emit `manifest.json` with timestamp, commit hash, and filter criteria during Darwin Core archive creation
- name compressed DwC bundles with semantic versions and include manifest inside
- document versioned exports and add integration tests
- avoid crashing when git metadata is unavailable by defaulting commit hash to `unknown`

## Testing
- `ruff check . --fix`
- `ruff check dwc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1023638832f92f59f74fe75baf9