### PR TITLE
Add GPT prompt loading tests

### DIFF
--- a/docs/gpt.md
+++ b/docs/gpt.md
@@ -22,3 +22,7 @@ files for different roles:
 The `[gpt]` section of [`../config/config.default.toml`](../config/config.default.toml)
 controls the model, fallback behaviour, prompt directory, and dry-run mode for
 offline testing.
+
+## Testing
+
+Unit tests in [../tests/unit/test_gpt_prompts.py](../tests/unit/test_gpt_prompts.py) load fixture templates from [../tests/resources/gpt_prompts](../tests/resources/gpt_prompts) to ensure custom prompt directories and legacy `*.prompt` files are honoured. Run `pytest` to validate these behaviours whenever prompts change.

--- a/tests/resources/gpt_prompts/custom/text_to_dwc.system.prompt
+++ b/tests/resources/gpt_prompts/custom/text_to_dwc.system.prompt
@@ -1,0 +1,1 @@
+custom system

--- a/tests/resources/gpt_prompts/custom/text_to_dwc.user.prompt
+++ b/tests/resources/gpt_prompts/custom/text_to_dwc.user.prompt
@@ -1,0 +1,1 @@
+custom user

--- a/tests/resources/gpt_prompts/legacy/text_to_dwc.prompt
+++ b/tests/resources/gpt_prompts/legacy/text_to_dwc.prompt
@@ -1,0 +1,1 @@
+legacy user

--- a/tests/unit/test_gpt_prompts.py
+++ b/tests/unit/test_gpt_prompts.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import importlib
+import pytest
+
+from engines.errors import EngineError
+
+load_messages = importlib.import_module("engines.gpt.text_to_dwc").load_messages
+
+RESOURCES = Path(__file__).resolve().parents[1] / "resources" / "gpt_prompts"
+
+
+def test_loads_from_custom_dir() -> None:
+    base = RESOURCES / "custom"
+    messages = load_messages("text_to_dwc", base)
+    expected = [
+        {"role": "system", "content": (base / "text_to_dwc.system.prompt").read_text()} ,
+        {"role": "user", "content": (base / "text_to_dwc.user.prompt").read_text()} ,
+    ]
+    assert messages == expected
+
+
+def test_falls_back_to_legacy_file() -> None:
+    base = RESOURCES / "legacy"
+    messages = load_messages("text_to_dwc", base)
+    expected = [{"role": "user", "content": (base / "text_to_dwc.prompt").read_text()}]
+    assert messages == expected
+
+
+def test_defaults_to_package_prompts() -> None:
+    messages = load_messages("text_to_dwc")
+    cfg = Path("config/prompts")
+    expected = [
+        {"role": "system", "content": (cfg / "text_to_dwc.system.prompt").read_text()},
+        {"role": "user", "content": (cfg / "text_to_dwc.user.prompt").read_text()},
+    ]
+    assert messages == expected
+
+
+def test_missing_user_prompt_raises(tmp_path: Path) -> None:
+    # Provide only a system prompt; should raise EngineError due to missing user prompt
+    prompt_dir = tmp_path
+    (prompt_dir / "text_to_dwc.system.prompt").write_text("only system")
+    with pytest.raises(EngineError):
+        load_messages("text_to_dwc", prompt_dir)


### PR DESCRIPTION
## Summary
- add fixtures for custom and legacy GPT prompts
- test load_messages behaviour for custom, legacy, and default prompt directories
- document GPT prompt testing strategy

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfc5ad9384832f9ab29408fd7c51bb