### PR TITLE
docs: note starter rule mappings and remaining gaps

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -10,8 +10,10 @@
   [`io_utils/candidates.py`](../io_utils/candidates.py) use raw SQLite. An ORM
   such as SQLAlchemy could clarify data models and migrations.
 - [`config/rules/dwc_rules.toml`](../config/rules/dwc_rules.toml) and
-  [`config/rules/vocab.toml`](../config/rules/vocab.toml) are empty templates
-  awaiting mapping logic.
+  [`config/rules/vocab.toml`](../config/rules/vocab.toml) now ship with starter
+  mappings for common field aliases and controlled terms, but many Darwin Core
+  fields—such as *habitat* or coordinate precision—and additional vocabulary
+  values remain unmapped.
 
 ## Potential improvements
 


### PR DESCRIPTION
## Summary
- note starter field and vocabulary mappings in rule files
- point out unmapped Darwin Core fields and vocabulary gaps

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfcfd0176c832f8791fa6abd6198d8