### PR TITLE
Implement GBIF taxonomy and locality verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - ✨ core Darwin Core field mappings and controlled vocabularies
 - ✨ load custom Darwin Core term mappings via `[dwc.custom]` config section
 - ✨ versioned Darwin Core Archive exports with run manifest
+- ✨ taxonomy and locality verification against GBIF with graceful error handling
 
 ### Fixed
 - 🐛 normalize `typeStatus` citations to lowercase using vocabulary rules

--- a/tests/unit/test_gbif_lookup.py
+++ b/tests/unit/test_gbif_lookup.py
@@ -1,0 +1,72 @@
+import json
+from urllib.error import URLError
+
+import qc.gbif as gbif_module
+from qc.gbif import LOCALITY_FIELDS, TAXONOMY_FIELDS, GbifLookup
+
+
+def _mock_response(data: object):
+    class MockResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def read(self):
+            return json.dumps(data).encode()
+
+    return MockResponse()
+
+
+def test_verify_taxonomy_success(monkeypatch):
+    gbif = GbifLookup()
+    record = {"scientificName": "Puma concolor"}
+
+    data = {field: f"value_{field}" for field in TAXONOMY_FIELDS}
+
+    monkeypatch.setattr(gbif_module, "urlopen", lambda url: _mock_response(data))
+
+    result = gbif.verify_taxonomy(record)
+    for field in TAXONOMY_FIELDS:
+        assert result[field] == data[field]
+
+
+def test_verify_taxonomy_error(monkeypatch):
+    gbif = GbifLookup()
+    record = {"scientificName": "Puma concolor"}
+
+    def raise_error(url):  # pragma: no cover - executed via monkeypatch
+        raise URLError("failure")
+
+    monkeypatch.setattr(gbif_module, "urlopen", raise_error)
+    result = gbif.verify_taxonomy(record)
+    assert result == record
+    assert result is not record
+
+
+def test_verify_locality_success(monkeypatch):
+    gbif = GbifLookup()
+    record = {"decimalLatitude": 45.0, "decimalLongitude": -75.0}
+
+    data = [{field: f"value_{field}" for field in LOCALITY_FIELDS}]
+
+    monkeypatch.setattr(gbif_module, "urlopen", lambda url: _mock_response(data))
+
+    result = gbif.verify_locality(record)
+    for field in LOCALITY_FIELDS:
+        assert result[field] == data[0][field]
+
+
+def test_verify_locality_error(monkeypatch):
+    gbif = GbifLookup()
+    record = {"decimalLatitude": 45.0, "decimalLongitude": -75.0}
+
+    def raise_error(url):  # pragma: no cover - executed via monkeypatch
+        raise URLError("failure")
+
+    monkeypatch.setattr(gbif_module, "urlopen", raise_error)
+    result = gbif.verify_locality(record)
+    assert result == record
+    assert result is not record
+


### PR DESCRIPTION
## Summary
- implement GBIF taxonomy and locality lookups with error handling
- add unit tests for lookup success and error conditions
- document GBIF verification in changelog

## Testing
- `ruff check . --fix`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfd4dadeec832fbc2b2bd84e1f9415