### PR TITLE
Fix GBIF taxonomy ID mapping from usage keys

### DIFF
--- a/qc/gbif.py
+++ b/qc/gbif.py
@@ -112,6 +112,11 @@ class GbifLookup:
         except (URLError, json.JSONDecodeError):
             return updated
 
+        if "usageKey" in data:
+            data["taxonKey"] = data["usageKey"]
+        if "acceptedUsageKey" in data:
+            data["acceptedTaxonKey"] = data["acceptedUsageKey"]
+
         for field in TAXONOMY_FIELDS:
             if field in data:
                 updated[field] = data[field]

--- a/tests/unit/test_gbif_lookup.py
+++ b/tests/unit/test_gbif_lookup.py
@@ -23,12 +23,21 @@ def test_verify_taxonomy_success(monkeypatch):
     gbif = GbifLookup()
     record = {"scientificName": "Puma concolor"}
 
-    data = {field: f"value_{field}" for field in TAXONOMY_FIELDS}
+    data = {
+        field: f"value_{field}"
+        for field in TAXONOMY_FIELDS
+        if field not in {"taxonKey", "acceptedTaxonKey"}
+    }
+    data["usageKey"] = "value_taxonKey"
+    data["acceptedUsageKey"] = "value_acceptedTaxonKey"
 
     monkeypatch.setattr(gbif_module, "urlopen", lambda url: _mock_response(data))
 
     result = gbif.verify_taxonomy(record)
-    for field in TAXONOMY_FIELDS:
+
+    assert result["taxonKey"] == "value_taxonKey"
+    assert result["acceptedTaxonKey"] == "value_acceptedTaxonKey"
+    for field in set(TAXONOMY_FIELDS) - {"taxonKey", "acceptedTaxonKey"}:
         assert result[field] == data[field]
 
 


### PR DESCRIPTION
## Summary
- map `usageKey` and `acceptedUsageKey` from GBIF responses to `taxonKey` and `acceptedTaxonKey`
- update unit tests for new taxonomy ID mapping

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfd74cf25c832f90ea322ef0079463