### PR TITLE
✅ strengthen GBIF QC and roadmap priority

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,7 +29,7 @@ Secondary tasks cover medium and low priority items detailed below.
 
 | Feature | Priority | Timeline |
 | --- | --- | --- |
-| Hook into [qc/gbif.py](../qc/gbif.py) for taxonomy validation | Medium | Q3 2025 |
+| Hook into [qc/gbif.py](../qc/gbif.py) for taxonomy validation | High | Q3 2025 |
 | Move GBIF API endpoints into configuration files | Low | Q2 2025 |
 | Implement locality cross-checks using Gazetteer API | Low | Q4 2025 |
 

--- a/qc/gbif.py
+++ b/qc/gbif.py
@@ -117,9 +117,7 @@ class GbifLookup:
         if "acceptedUsageKey" in data:
             data["acceptedTaxonKey"] = data["acceptedUsageKey"]
 
-        for field in TAXONOMY_FIELDS:
-            if field in data:
-                updated[field] = data[field]
+        updated.update({field: data[field] for field in TAXONOMY_FIELDS if field in data})
 
         return updated
 
@@ -161,9 +159,7 @@ class GbifLookup:
         elif not isinstance(data, dict):
             return updated
 
-        for field in LOCALITY_FIELDS:
-            if field in data:
-                updated[field] = data[field]
+        updated.update({field: data[field] for field in LOCALITY_FIELDS if field in data})
 
         return updated
 

--- a/tests/unit/test_gbif_lookup.py
+++ b/tests/unit/test_gbif_lookup.py
@@ -54,6 +54,20 @@ def test_verify_taxonomy_error(monkeypatch):
     assert result is not record
 
 
+def test_verify_taxonomy_missing_fields(monkeypatch):
+    gbif = GbifLookup()
+    record: dict = {}
+
+    def raise_if_called(url):  # pragma: no cover - executed via monkeypatch
+        raise AssertionError("urlopen should not be called")
+
+    monkeypatch.setattr(gbif_module, "urlopen", raise_if_called)
+    result = gbif.verify_taxonomy(record)
+
+    assert result == record
+    assert result is not record
+
+
 def test_verify_locality_success(monkeypatch):
     gbif = GbifLookup()
     record = {"decimalLatitude": 45.0, "decimalLongitude": -75.0}
@@ -76,6 +90,31 @@ def test_verify_locality_error(monkeypatch):
 
     monkeypatch.setattr(gbif_module, "urlopen", raise_error)
     result = gbif.verify_locality(record)
+    assert result == record
+    assert result is not record
+
+
+def test_verify_locality_missing_coords(monkeypatch):
+    gbif = GbifLookup()
+    record: dict = {}
+
+    def raise_if_called(url):  # pragma: no cover - executed via monkeypatch
+        raise AssertionError("urlopen should not be called")
+
+    monkeypatch.setattr(gbif_module, "urlopen", raise_if_called)
+    result = gbif.verify_locality(record)
+
+    assert result == record
+    assert result is not record
+
+
+def test_verify_locality_empty_response(monkeypatch):
+    gbif = GbifLookup()
+    record = {"decimalLatitude": 45.0, "decimalLongitude": -75.0}
+
+    monkeypatch.setattr(gbif_module, "urlopen", lambda url: _mock_response([]))
+    result = gbif.verify_locality(record)
+
     assert result == record
     assert result is not record
 


### PR DESCRIPTION
## Summary
- refine GBIF verification helpers to update fields from query maps
- test GBIF lookups for missing data and empty responses
- elevate GBIF taxonomy validation to High priority in the roadmap

## Testing
- `ruff check . --fix`
- `ruff .` *(fails: unrecognized subcommand)*
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfdfe0141c832fabe92920dd68dea5