### PR TITLE
Add mappings for habitat and coordinate precision

### DIFF
--- a/config/rules/dwc_rules.toml
+++ b/config/rules/dwc_rules.toml
@@ -13,4 +13,11 @@ collector = "recordedBy"
 country = "country"
 province = "stateProvince"
 locality = "locality"
+
+# Geographic precision
+"coordinate precision" = "coordinatePrecision"
+
+# Ecological context
+habitat = "habitat"
+
 "scientific name" = "scientificName"

--- a/config/rules/vocab.toml
+++ b/config/rules/vocab.toml
@@ -15,3 +15,15 @@ Isotype = "isotype"
 Paratype = "paratype"
 Lectotype = "lectotype"
 Neotype = "neotype"
+
+[habitat]
+# Normalise habitat descriptions
+bog = "bog"
+forest = "forest"
+wetland = "wetland"
+
+[coordinatePrecision]
+# Convert precision units to decimal degrees
+"1 m" = "0.00001"
+"10 m" = "0.0001"
+"100 m" = "0.001"

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,10 +10,10 @@
   [`io_utils/candidates.py`](../io_utils/candidates.py) use raw SQLite. An ORM
   such as SQLAlchemy could clarify data models and migrations.
 - [`config/rules/dwc_rules.toml`](../config/rules/dwc_rules.toml) and
-  [`config/rules/vocab.toml`](../config/rules/vocab.toml) now ship with starter
-  mappings for common field aliases and controlled terms, but many Darwin Core
-  fields—such as *habitat* or coordinate precision—and additional vocabulary
-  values remain unmapped.
+  [`config/rules/vocab.toml`](../config/rules/vocab.toml) include aliases for
+  fields such as *habitat* and coordinate precision along with starter
+  vocabularies for habitat descriptions and precision units. Additional Darwin
+  Core terms and value mappings can be added as new sources emerge.
 
 ## Potential improvements
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ Upcoming features and priorities for the herbarium OCR to Darwin Core toolkit.
 - Integrate multilingual OCR models for non-English labels
 - Configurable mapping from custom schemas via the [`[dwc]` section](configuration.md)
 - Versioned DwC-A export bundles with embedded manifest
+- Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml`
 
 Secondary tasks cover medium and low priority items detailed below.
 
@@ -22,7 +23,7 @@ Secondary tasks cover medium and low priority items detailed below.
 | Feature | Priority | Timeline |
 | --- | --- | --- |
 | Configurable mapping from custom schemas via the [`[dwc]` section](configuration.md) | High | Q2 2025 |
-| Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml` | Medium | Q2 2025 |
+| Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml` | High | Q2 2025 |
 | Auto-generate Darwin Core term mappings from external XSD | Low | Q4 2025 |
 
 ## Quality control


### PR DESCRIPTION
## Summary
- map habitat and coordinate precision fields to their Darwin Core terms
- expand vocabularies for habitat descriptions and coordinate precision units
- flag mapping rule completion as a high-priority roadmap item and document new vocabulary sources

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfe1abd878832fbf588f606c3cd125