### PR TITLE
Fix PaddleOCR language configuration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -161,7 +161,7 @@ def process_image(
                 kwargs: Dict[str, Any] = {}
                 ocr_cfg = cfg.get("ocr", {})
                 langs = ocr_cfg.get("langs")
-                if langs:
+                if langs and preferred != "paddleocr":
                     kwargs["langs"] = langs
                 if preferred == "gpt":
                     gpt_cfg = cfg.get("gpt", {})
@@ -179,6 +179,9 @@ def process_image(
                     )
                     if t_cfg.get("model_paths"):
                         kwargs["model_paths"] = t_cfg["model_paths"]
+                elif preferred == "paddleocr":
+                    p_cfg = cfg.get("paddleocr", {})
+                    kwargs.update(lang=p_cfg.get("lang", "en"))
                 text, confidences = dispatch(
                     step, image=proc_path, engine=preferred, **kwargs
                 )


### PR DESCRIPTION
## Summary
- supply PaddleOCR-specific language setting when dispatching OCR

## Testing
- `ruff check . --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfedd2c36c832f9396dea31332f19f