### PR TITLE
Replace GPT prompt placeholders before dispatch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -213,6 +213,7 @@ def process_image(
                     event["engine_version"] = engine_version
             elif step == "text_to_dwc":
                 gpt_cfg = cfg.get("gpt", {})
+                dwc_cfg = cfg.get("dwc", {})
                 dwc_data, field_conf = dispatch(
                     step,
                     text=text or "",
@@ -220,6 +221,7 @@ def process_image(
                     model=gpt_cfg.get("model", "gpt-4"),
                     dry_run=gpt_cfg.get("dry_run", False),
                     prompt_dir=prompt_dir,
+                    fields=dwc_cfg.get("strict_minimal_fields"),
                 )
                 ident_history = dwc_data.pop("identificationHistory", [])
                 event["dwc"] = dwc_data

--- a/engines/gpt/image_to_text.py
+++ b/engines/gpt/image_to_text.py
@@ -60,9 +60,12 @@ def image_to_text(
         model infers the language automatically.
     """
     messages = load_messages("image_to_text", prompt_dir)
-    if langs:
-        lang_hint = ", ".join(langs)
+    lang_hint = ", ".join(langs) if langs else None
+    if lang_hint:
         messages.insert(0, {"role": "system", "content": f"Languages: {lang_hint}"})
+    replace_lang = lang_hint or "the source language"
+    for msg in messages:
+        msg["content"] = msg["content"].replace("%LANG%", replace_lang)
     if dry_run:
         return "", []
     if OpenAI is None:

--- a/engines/gpt/text_to_dwc.py
+++ b/engines/gpt/text_to_dwc.py
@@ -42,14 +42,32 @@ def text_to_dwc(
     model: str,
     dry_run: bool = False,
     prompt_dir: Optional[Path] = None,
+    fields: Optional[List[str]] = None,
 ) -> Tuple[Dict[str, str], Dict[str, float]]:
     """Map unstructured text to Darwin Core terms using a GPT model.
 
     The model is expected to return JSON where each key is a Darwin Core
     term mapping to a dictionary containing ``value`` and ``confidence``
     entries.  Any parsing errors result in empty outputs.
+
+    Parameters
+    ----------
+    text:
+        Unstructured text to map.
+    model:
+        The GPT model name to use.
+    dry_run:
+        When ``True`` or when the OpenAI SDK is unavailable, no network
+        call is performed and empty results are returned.
+    prompt_dir:
+        Optional directory containing prompt templates.
+    fields:
+        Optional list of Darwin Core fields to emphasise in the prompt.
     """
     messages = load_messages("text_to_dwc", prompt_dir)
+    field_hint = ", ".join(fields) if fields else "required"
+    for msg in messages:
+        msg["content"] = msg["content"].replace("%FIELD%", field_hint)
     if dry_run:
         return {}, {}
     if OpenAI is None:

--- a/tests/unit/test_gpt_image_to_text.py
+++ b/tests/unit/test_gpt_image_to_text.py
@@ -69,7 +69,7 @@ def test_includes_language_hints(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         gpt_image_to_text,
         "load_messages",
-        lambda task, prompt_dir=None: [{"role": "user", "content": "prompt"}],
+        lambda task, prompt_dir=None: [{"role": "user", "content": "Respond in %LANG%"}],
     )
 
     text, confidences = gpt_image_to_text.image_to_text(
@@ -77,5 +77,6 @@ def test_includes_language_hints(monkeypatch, tmp_path: Path) -> None:
     )
 
     assert captured["messages"][0]["content"].endswith("eng, spa")
+    assert captured["messages"][1]["content"][0]["text"] == "Respond in eng, spa"
     assert text == "hola"
     assert confidences == [0.8]

--- a/tests/unit/test_gpt_text_to_dwc.py
+++ b/tests/unit/test_gpt_text_to_dwc.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+import importlib
+
+
+gpt_text_to_dwc = importlib.import_module("engines.gpt.text_to_dwc")
+
+
+def test_replaces_field_placeholder(monkeypatch):
+    captured = {}
+    resp = SimpleNamespace(output_text="{}")
+
+    def fake_create(**kwargs):
+        captured["messages"] = kwargs.get("input")
+        return resp
+
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(gpt_text_to_dwc, "OpenAI", lambda: fake_client)
+    monkeypatch.setattr(
+        gpt_text_to_dwc,
+        "load_messages",
+        lambda task, prompt_dir=None: [{"role": "user", "content": "Ensure %FIELD%"}],
+    )
+
+    gpt_text_to_dwc.text_to_dwc("data", model="gpt-4", fields=["catalogNumber", "eventDate"])
+
+    assert captured["messages"][0]["content"].startswith("Ensure catalogNumber, eventDate")


### PR DESCRIPTION
## Summary
- replace `%LANG%` and `%FIELD%` tokens in GPT prompts with runtime values
- pass minimal Darwin Core fields from CLI to text-to-DwC engine
- test placeholder substitution for image-to-text and text-to-dwc prompts

## Testing
- `ruff check . --fix`
- `pytest`
- `python review_tui.py --check-prompts`


------
https://chatgpt.com/codex/tasks/task_e_68bff8001984832fb54319ee38425b5d