### PR TITLE
✨ add optional GBIF QC lookups

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,12 +6,11 @@
 
 ## Medium priority
 
-1. Integrate GBIF taxonomy and locality verification into the QC pipeline (context: `qc/gbif.py`) – _medium_.
-2. Support full schema parsing from official Darwin Core and ABCD XSDs – _medium_.
-3. Add evaluation harness for GPT prompt template coverage – _medium_.
-4. Support GPU-accelerated inference for Tesseract – _medium_.
-5. Transition pipeline storage to an ORM – _medium_.
-6. Add audit trail for import steps with explicit user sign-off – _medium_.
+1. Support full schema parsing from official Darwin Core and ABCD XSDs – _medium_.
+2. Add evaluation harness for GPT prompt template coverage – _medium_.
+3. Support GPU-accelerated inference for Tesseract – _medium_.
+4. Transition pipeline storage to an ORM – _medium_.
+5. Add audit trail for import steps with explicit user sign-off – _medium_.
 
 ## Low priority
 

--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -61,6 +61,7 @@ low_confidence_flag = true
 top_fifth_scan_pct = 20
 
 [qc.gbif]
+enabled = false
 species_match_endpoint = "https://api.gbif.org/v1/species/match"
 reverse_geocode_endpoint = "https://api.gbif.org/v1/geocode/reverse"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,10 +71,11 @@ experiment with other vocabularies.
 
 ## GBIF endpoints
 
-Quality-control tasks can query GBIF for taxonomy and locality validation. Override the default API endpoints by setting the `[qc.gbif]` section:
+Quality-control tasks can query GBIF for taxonomy and locality validation. Enable the lookups and override the default API endpoints in the `[qc.gbif]` section:
 
 ```toml
 [qc.gbif]
+enabled = true
 species_match_endpoint = "https://api.gbif.org/v1/species/match"
 reverse_geocode_endpoint = "https://api.gbif.org/v1/geocode/reverse"
 ```

--- a/docs/qc.md
+++ b/docs/qc.md
@@ -22,10 +22,15 @@ Use the arrow keys to highlight a candidate and press Enter to confirm. The chos
 
 ## GBIF lookups
 
-Taxonomy and locality checks can call the GBIF API. The endpoints are configurable through the `[qc.gbif]` section of `config.toml` so deployments can target mirrors or staging servers:
+When enabled, the pipeline verifies taxonomy and locality with the GBIF API after mapping OCR output to Darwin Core. Any fields added by GBIF are recorded in the event log and written to the CSV output. Mismatches update the `flags` column so reviewers can spot corrections.
+
+Toggle these checks and override API endpoints in the `[qc.gbif]` section of `config.toml`:
 
 ```toml
 [qc.gbif]
+enabled = true
 species_match_endpoint = "https://api.gbif.org/v1/species/match"
 reverse_geocode_endpoint = "https://api.gbif.org/v1/geocode/reverse"
 ```
+
+See the [configuration](./configuration.md#gbif-endpoints) guide for details on these settings.

--- a/tests/unit/test_qc.py
+++ b/tests/unit/test_qc.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import qc
+import cli
 from cli import load_config
 from qc.gbif import (
     DEFAULT_REVERSE_GEOCODE_ENDPOINT,
@@ -11,6 +12,16 @@ from qc.gbif import (
     GbifLookup,
 )
 from dwc.mapper import map_ocr_to_dwc
+from PIL import Image
+
+
+def _fake_dispatch(step, **kwargs):
+    if step == "image_to_text":
+        return "text", [0.9]
+    return (
+        {"scientificName": "Orig", "decimalLatitude": "1", "decimalLongitude": "2"},
+        {"scientificName": 0.9},
+    )
 
 
 def test_detect_duplicates_hash_collision():
@@ -76,3 +87,107 @@ def test_map_ocr_to_dwc_rules() -> None:
     assert record.catalogNumber == "ABC123"
     assert record.basisOfRecord == "PreservedSpecimen"
     assert record.typeStatus == "holotype"
+
+
+def test_process_image_gbif_success(monkeypatch, tmp_path):
+    img_path = tmp_path / "img.png"
+    Image.new("RGB", (10, 10), "white").save(img_path)
+    cfg = {
+        "ocr": {"enabled_engines": ["test"], "preferred_engine": "test", "allow_tesseract_on_macos": True},
+        "gpt": {"model": "gpt-4.1-mini", "dry_run": True},
+        "qc": {"gbif": {"enabled": True}},
+        "preprocess": {},
+    }
+    monkeypatch.setattr(cli, "available_engines", lambda step: ["test"])
+    monkeypatch.setattr(cli, "preprocess_image", lambda p, c: p)
+    monkeypatch.setattr(cli, "compute_sha256", lambda p: "hash")
+    monkeypatch.setattr(cli, "dispatch", _fake_dispatch)
+    monkeypatch.setattr(cli, "get_fallback_policy", lambda engine: None)
+    monkeypatch.setattr(cli.qc, "detect_duplicates", lambda *a, **k: [])
+    monkeypatch.setattr(cli.qc, "flag_low_confidence", lambda *a, **k: [])
+    monkeypatch.setattr(cli.qc, "flag_top_fifth", lambda *a, **k: [])
+    monkeypatch.setattr(cli, "insert_specimen", lambda conn, specimen: None)
+    monkeypatch.setattr(cli, "fetch_processing_state", lambda conn, sid, mod: None)
+    monkeypatch.setattr(cli, "upsert_processing_state", lambda conn, state: None)
+    monkeypatch.setattr(
+        cli,
+        "record_failure",
+        lambda *a, **k: cli.ProcessingState(
+            specimen_id="1", module="process", status="error", retries=0, error="", confidence=None
+        ),
+    )
+
+    class DummyGbif:
+        def verify_taxonomy(self, record):
+            updated = record.copy()
+            updated["scientificName"] = "Corrected"
+            updated["kingdom"] = "Plantae"
+            return updated
+
+        def verify_locality(self, record):
+            updated = record.copy()
+            updated["country"] = "Canada"
+            return updated
+
+    monkeypatch.setattr(cli.qc.GbifLookup, "from_config", lambda cfg: DummyGbif())
+    cand_session = cli.init_candidate_db(tmp_path / "candidates.db")
+    app_conn = cli.init_app_db(tmp_path / "app.db")
+    event, dwc_row, ident_rows = cli.process_image(
+        img_path, cfg, "run1", {}, cand_session, app_conn, 3, False
+    )
+    cand_session.close()
+    app_conn.close()
+    assert set(event["added_fields"]) == {"kingdom", "country"}
+    assert "gbif:scientificName" in event["flags"]
+    assert event["dwc"]["scientificName"] == "Corrected"
+    assert dwc_row["country"] == "Canada"
+    assert "gbif:scientificName" in event["dwc"]["flags"]
+
+
+def test_process_image_gbif_failure(monkeypatch, tmp_path):
+    img_path = tmp_path / "img.png"
+    Image.new("RGB", (10, 10), "white").save(img_path)
+    cfg = {
+        "ocr": {"enabled_engines": ["test"], "preferred_engine": "test", "allow_tesseract_on_macos": True},
+        "gpt": {"model": "gpt-4.1-mini", "dry_run": True},
+        "qc": {"gbif": {"enabled": True}},
+        "preprocess": {},
+    }
+    monkeypatch.setattr(cli, "available_engines", lambda step: ["test"])
+    monkeypatch.setattr(cli, "preprocess_image", lambda p, c: p)
+    monkeypatch.setattr(cli, "compute_sha256", lambda p: "hash")
+    monkeypatch.setattr(cli, "dispatch", _fake_dispatch)
+    monkeypatch.setattr(cli, "get_fallback_policy", lambda engine: None)
+    monkeypatch.setattr(cli.qc, "detect_duplicates", lambda *a, **k: [])
+    monkeypatch.setattr(cli.qc, "flag_low_confidence", lambda *a, **k: [])
+    monkeypatch.setattr(cli.qc, "flag_top_fifth", lambda *a, **k: [])
+    monkeypatch.setattr(cli, "insert_specimen", lambda conn, specimen: None)
+    monkeypatch.setattr(cli, "fetch_processing_state", lambda conn, sid, mod: None)
+    monkeypatch.setattr(cli, "upsert_processing_state", lambda conn, state: None)
+    monkeypatch.setattr(
+        cli,
+        "record_failure",
+        lambda *a, **k: cli.ProcessingState(
+            specimen_id="1", module="process", status="error", retries=0, error="", confidence=None
+        ),
+    )
+
+    class FailingGbif:
+        def verify_taxonomy(self, record):
+            raise RuntimeError("boom")
+
+        def verify_locality(self, record):  # pragma: no cover - not called
+            return record
+
+    monkeypatch.setattr(cli.qc.GbifLookup, "from_config", lambda cfg: FailingGbif())
+    cand_session = cli.init_candidate_db(tmp_path / "candidates.db")
+    app_conn = cli.init_app_db(tmp_path / "app.db")
+    event, dwc_row, ident_rows = cli.process_image(
+        img_path, cfg, "run1", {}, cand_session, app_conn, 3, False
+    )
+    cand_session.close()
+    app_conn.close()
+    assert "boom" in event["errors"][0]
+    assert event["added_fields"] == []
+    assert "gbif:scientificName" not in event["flags"]
+    assert dwc_row["scientificName"] == "Orig"


### PR DESCRIPTION
## Summary
- enable toggleable GBIF taxonomy and locality checks
- record GBIF-added fields and mismatch flags in event logs and CSVs
- document and test GBIF QC behaviour

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bff8828df0832f97889001ee0a55a9