### PR TITLE
🐛 ensure import audits use app database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 - ✨ load custom Darwin Core term mappings via `[dwc.custom]` config section
 - ✨ versioned Darwin Core Archive exports with run manifest
 - ✨ taxonomy and locality verification against GBIF with graceful error handling
+- ✨ track review bundle imports with audit entries
 
 ### Fixed
 - 🐛 normalize `typeStatus` citations to lowercase using vocabulary rules
+- 🐛 record review import audits in the main application database
 
 ### Docs
 - 📝 document adaptive thresholding options in preprocessing and configuration guides

--- a/docs/export_and_reporting.md
+++ b/docs/export_and_reporting.md
@@ -42,10 +42,11 @@ Exports operate on the pipeline's SQLite database and never touch the main DwC+A
 
 Use [import_review.py](../import_review.py) to merge reviewed decisions into the
 working database. The command records an audit entry with the user ID, bundle
-hash and timestamp. Provide the user via `--user`:
+hash and timestamp. Audits are written to `app.db` next to the candidates file
+unless an explicit path is provided via `--app-db`.
 
 ```bash
-python import_review.py output/review_v1.2.0.zip output/candidates.db --schema-version 1.2.0 --user alice
+python import_review.py output/review_v1.2.0.zip output/candidates.db --schema-version 1.2.0 --user alice --app-db output/app.db
 ```
 
 Audit records are accessible with `fetch_import_audit` in

--- a/docs/review_workflow.md
+++ b/docs/review_workflow.md
@@ -78,6 +78,6 @@ with sqlite3.connect("output/candidates.db") as conn:
 Merge reviewed selections back into your working database with [import_review.py](../import_review.py):
 
 ```
-python import_review.py output/review_v1.2.0.zip output/candidates.db --schema-version 1.2.0
+python import_review.py output/review_v1.2.0.zip output/candidates.db --schema-version 1.2.0 --user alice
 ```
 

--- a/import_review.py
+++ b/import_review.py
@@ -23,7 +23,11 @@ def verify_manifest(manifest: dict, expected_version: str) -> None:
 
 
 def import_bundle(
-    bundle: Path, db_path: Path, schema_version: str, user: str
+    bundle: Path,
+    candidates_db: Path,
+    schema_version: str,
+    user: str,
+    app_db: Path | None = None,
 ) -> None:
     bundle_hash = compute_sha256(bundle)
     with zipfile.ZipFile(bundle) as zf:
@@ -32,11 +36,12 @@ def import_bundle(
         with tempfile.TemporaryDirectory() as tmpdir:
             zf.extract("candidates.db", tmpdir)
             src_session = init_candidate_db(Path(tmpdir) / "candidates.db")
-            dest_session = init_candidate_db(db_path)
+            dest_session = init_candidate_db(candidates_db)
             import_decisions(dest_session, src_session)
             src_session.close()
             dest_session.close()
-    audit_session = init_app_db(db_path)
+    app_db_path = app_db or candidates_db.with_name("app.db")
+    audit_session = init_app_db(app_db_path)
     insert_import_audit(audit_session, user, bundle_hash)
     audit_session.close()
 
@@ -49,8 +54,15 @@ def main() -> None:
         "--schema-version", required=True, help="Expected schema version"
     )
     parser.add_argument("--user", required=True, help="User ID for auditing")
+    parser.add_argument(
+        "--app-db",
+        type=Path,
+        help="Application database (defaults to app.db next to candidates.db)",
+    )
     args = parser.parse_args()
-    import_bundle(args.bundle, args.db, args.schema_version, args.user)
+    import_bundle(
+        args.bundle, args.db, args.schema_version, args.user, args.app_db
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_import_review.py
+++ b/tests/unit/test_import_review.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import zipfile
+from pathlib import Path
+
+from import_review import import_bundle
+from io_utils.candidates import init_db as init_candidate_db
+from io_utils.database import fetch_import_audit, init_db as init_app_db
+from io_utils.read import compute_sha256
+
+
+def test_import_bundle_records_audit_in_app_db(tmp_path: Path) -> None:
+    src_db = tmp_path / "src_candidates.db"
+    src_session = init_candidate_db(src_db)
+    src_session.close()
+
+    manifest = {
+        "commit": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "schema_version": "1.0.0",
+    }
+    bundle_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(bundle_path, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        zf.write(src_db, "candidates.db")
+
+    dest_db = tmp_path / "candidates.db"
+    app_db = tmp_path / "app.db"
+    import_bundle(bundle_path, dest_db, "1.0.0", "alice", app_db)
+
+    conn = init_app_db(app_db)
+    bundle_hash = compute_sha256(bundle_path)
+    audit = fetch_import_audit(conn, bundle_hash)
+    assert audit and audit.user_id == "alice"
+    conn.close()


### PR DESCRIPTION
## Summary
- default import audits to `app.db` and allow overriding with `--app-db`
- document audit database behavior and update review import guidance
- test import bundle auditing

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0066cadc8832fa4f78cb3b61e5cdc