### PR TITLE
Align development and contributing docs with roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Follow the repository's guidelines in [AGENTS.md](AGENTS.md) and run `ruff check . --fix` and `pytest` before submitting changes.
+
+Review [docs/development.md](docs/development.md) for development conventions and consult the [roadmap](docs/roadmap.md) for open tasks and priorities.

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ for details.
 
 ## Development
 
-Consult [docs/development.md](docs/development.md) for open stubs and ideas for
-future contributions. The project [roadmap](docs/roadmap.md) outlines upcoming
-features, priorities, and timelines.
+Consult [docs/development.md](docs/development.md) for development guidelines.
+The project [roadmap](docs/roadmap.md) outlines upcoming features, priorities,
+and timelines.
 
 ### Commit messages
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,24 +1,9 @@
 # Development guide
 
-## Open stubs and placeholders
+## General guidelines
 
-- [`qc/gbif.py`](../qc/gbif.py) provides taxonomy and locality lookups, but the
-  QC pipeline does not yet call them.
-- [`dwc/schema.py`](../dwc/schema.py) hard-codes Darwin Core terms. Loading terms
-  from a configured schema or XSD remains a future task.
-- [`io_utils/database.py`](../io_utils/database.py) and
-  [`io_utils/candidates.py`](../io_utils/candidates.py) use raw SQLite. An ORM
-  such as SQLAlchemy could clarify data models and migrations.
-- [`config/rules/dwc_rules.toml`](../config/rules/dwc_rules.toml) and
-  [`config/rules/vocab.toml`](../config/rules/vocab.toml) include aliases for
-  fields such as *habitat* and coordinate precision along with starter
-  vocabularies for habitat descriptions and precision units. Additional Darwin
-  Core terms and value mappings can be added as new sources emerge.
+The [roadmap](roadmap.md) is the single source for open tasks, priorities, and timelines. Review it before starting work or filing a pull request to avoid duplication.
 
-## Potential improvements
-
-- Support alternative schemas via the `[dwc]` section in configuration and map
-  URIs accordingly.
-- Introduce an ORM layer for the pipeline database to improve readability and
-  enable richer queries.
-- Expand documentation for each processing phase with reproducible examples.
+- Keep preprocessing, OCR, mapping, QC, import, and export phases decoupled.
+- Prefer configuration-driven behavior and avoid hard-coded values.
+- Document new processing phases with reproducible examples.


### PR DESCRIPTION
## Summary
- point development guide to docs/roadmap
- add CONTRIBUTING.md referencing development guide and roadmap
- update README development section to remove open stubs reference

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0690e3d58832fb4999b5b1ff2a0ad