### PR TITLE
Skip roadmap writes during dry runs

### DIFF
--- a/scripts/create_roadmap_issues.py
+++ b/scripts/create_roadmap_issues.py
@@ -137,7 +137,10 @@ def main() -> None:
         print(f"Created issue for '{task.description}': {url}")
 
     new_text = replace_issue_links(text, replacements)
-    roadmap_path.write_text(new_text, encoding="utf-8")
+    if args.dry_run:
+        print("Dry run; roadmap not modified")
+    else:
+        roadmap_path.write_text(new_text, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_create_roadmap_issues.py
+++ b/tests/unit/test_create_roadmap_issues.py
@@ -1,3 +1,7 @@
+import os
+import subprocess
+import sys
+
 from scripts.create_roadmap_issues import parse_roadmap, replace_issue_links
 
 
@@ -19,3 +23,27 @@ def test_replace_issue_links():
     replacements = {0: "https://example.com/1"}
     updated = replace_issue_links(text, replacements)
     assert "(https://example.com/1)" in updated
+
+
+def test_dry_run_does_not_modify_file(tmp_path, monkeypatch):
+    text = "- Task one — **High**, Q2 2025 (Issue TBD)\n"
+    roadmap = tmp_path / "roadmap.md"
+    roadmap.write_text(text)
+
+    env = os.environ.copy()
+    env["GITHUB_TOKEN"] = "x"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/create_roadmap_issues.py",
+            "--repo",
+            "org/repo",
+            "--roadmap",
+            str(roadmap),
+            "--dry-run",
+        ],
+        check=True,
+        env=env,
+    )
+
+    assert roadmap.read_text() == text


### PR DESCRIPTION
## Summary
- prevent placeholder links from overwriting roadmap during dry runs
- test that dry runs leave roadmap unchanged

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b40e69a4832fb2e16ae561460717