### PR TITLE
Expand mapping and vocabulary rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - :seedling: uv lockfile and bootstrap script for quick environment setup
+- :label: expand mapping rules for collector numbers and field note vocabulary
 
 ### Fixed
 - :bug: bootstrap script installs uv if missing

--- a/config/rules/dwc_rules.toml
+++ b/config/rules/dwc_rules.toml
@@ -7,6 +7,8 @@
 barcode = "catalogNumber"
 # Collector name appearing on labels
 collector = "recordedBy"
+# Collector-assigned specimen number
+"collector number" = "recordNumber"
 # Verbatim date strings found on sheets
 "date collected" = "eventDate"
 # Geographic annotations

--- a/config/rules/vocab.toml
+++ b/config/rules/vocab.toml
@@ -7,6 +7,7 @@
 "preserved specimen" = "PreservedSpecimen"
 "fossil" = "FossilSpecimen"
 "observation" = "HumanObservation"
+"field note" = "HumanObservation"
 
 [typeStatus]
 # Normalise type citations

--- a/docs/mapping_and_vocabulary.md
+++ b/docs/mapping_and_vocabulary.md
@@ -30,6 +30,9 @@ record = map_ocr_to_dwc({"barcode": "ABC123"})
 
 The resulting `record.catalogNumber` is `"ABC123"`.
 
+The default rules already map common labels such as `collector number` to
+`recordNumber` via [`dwc_rules.toml`](../config/rules/dwc_rules.toml).
+
 ## Vocabulary normalisation example
 
 Controlled terms such as `basisOfRecord` are harmonised via
@@ -42,3 +45,5 @@ normalize_vocab("herbarium sheet", "basisOfRecord")
 ```
 
 This call returns `"PreservedSpecimen"`.
+
+Passing `"field note"` instead normalises the value to `"HumanObservation"`.

--- a/tests/unit/test_qc.py
+++ b/tests/unit/test_qc.py
@@ -11,7 +11,7 @@ from qc.gbif import (
     DEFAULT_SPECIES_MATCH_ENDPOINT,
     GbifLookup,
 )
-from dwc.mapper import map_ocr_to_dwc
+from dwc import map_ocr_to_dwc, normalize_vocab
 from PIL import Image
 
 
@@ -76,6 +76,7 @@ def test_map_ocr_to_dwc_rules() -> None:
     record = map_ocr_to_dwc(
         {
             "collector": "Jane Doe",
+            "collector number": "42",
             "date collected": "2025-09-01",
             "barcode": "ABC123",
             "basisOfRecord": "herbarium sheet",
@@ -85,8 +86,13 @@ def test_map_ocr_to_dwc_rules() -> None:
     assert record.recordedBy == "Jane Doe"
     assert record.eventDate == "2025-09-01"
     assert record.catalogNumber == "ABC123"
+    assert record.recordNumber == "42"
     assert record.basisOfRecord == "PreservedSpecimen"
     assert record.typeStatus == "holotype"
+
+
+def test_normalize_vocab_field_note() -> None:
+    assert normalize_vocab("field note", "basisOfRecord") == "HumanObservation"
 
 
 def test_process_image_gbif_success(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add default `collector number` alias to Darwin Core record mappings
- normalize `field note` values to `HumanObservation`
- document built-in alias and vocab examples

## Testing
- `ruff check . --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b756d7dc832fb0be2d81b5912033