### PR TITLE
Add prompt coverage harness stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - :seedling: uv lockfile and bootstrap script for quick environment setup
+- :test_tube: prompt coverage harness stub
 
 ### Fixed
 - :bug: bootstrap script installs uv if missing

--- a/docs/gpt.md
+++ b/docs/gpt.md
@@ -40,3 +40,8 @@ pytest tests/unit/test_prompt_coverage.py
 # or
 python review_tui.py --check-prompts
 ```
+Use the standalone harness to print missing placeholders:
+
+```bash
+python scripts/prompt_coverage.py
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,5 +44,5 @@ Secondary tasks cover medium and low priority items detailed below.
 
 ## Testing and documentation
 
-- Add evaluation harness for GPT prompt template coverage — **Medium**, Q2 2025
+- Add evaluation harness for GPT prompt template coverage — **Medium**, Q2 2025 (see `scripts/prompt_coverage.py`)
 - Expand procedural examples across docs — **Low**, Q3 2025

--- a/scripts/prompt_coverage.py
+++ b/scripts/prompt_coverage.py
@@ -1,0 +1,35 @@
+"""Evaluate GPT prompt template coverage."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engines.gpt.image_to_text import load_messages
+
+REQUIRED_PLACEHOLDERS = {
+    "image_to_text": ["%LANG%"],
+    "text_to_dwc": ["%FIELD%"],
+    "image_to_dwc": ["%FIELD%"],
+}
+
+
+def evaluate() -> int:
+    """Return 0 if all required placeholders are present."""
+    missing: list[str] = []
+    for task, placeholders in REQUIRED_PLACEHOLDERS.items():
+        messages = load_messages(task)
+        content = "\n".join(m["content"] for m in messages)
+        for token in placeholders:
+            if token not in content:
+                missing.append(f"{task}: {token}")
+    if missing:
+        for m in missing:
+            print(f"missing placeholder {m}")
+        return 1
+    print("all prompts contain required placeholders")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(evaluate())


### PR DESCRIPTION
## Summary
- add stub script to evaluate GPT prompt placeholders
- document harness and roadmap reference
- record addition in changelog

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c0b756d7dc832fb0be2d81b5912033