### PR TITLE
Clarify Ruff usage in docs and AGENTS instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Fixed
 - :bug: bootstrap script installs uv if missing
 
+### Docs
+- 📝 clarify Ruff commands in AGENTS instructions and development guide
+
 ## [0.1.4] - 2025-09-10 (0.1.4)
 
 ### Added

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -10,4 +10,4 @@
 - Reviewers should verify these documentation updates during PR review.
 
 ## Testing
-- Run `ruff .` and `pytest` from the repository root before committing documentation changes.
+- Run `ruff check docs` and `pytest` from the repository root before committing documentation changes.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,3 +7,7 @@ The [roadmap](roadmap.md) is the single source for open tasks, priorities, and t
 - Keep preprocessing, OCR, mapping, QC, import, and export phases decoupled.
 - Prefer configuration-driven behavior and avoid hard-coded values.
 - Document new processing phases with reproducible examples.
+
+## Testing and linting
+
+Run `ruff check .` and `pytest` from the project root to validate changes before committing.

--- a/dwc/AGENTS.md
+++ b/dwc/AGENTS.md
@@ -7,4 +7,4 @@
 - Expand unit tests to cover new terms or transformations.
 
 ## Testing
-- After changes in this directory, run `ruff dwc` and the project test suite (`pytest`) from the repository root.
+- After changes in this directory, run `ruff check dwc` and the project test suite (`pytest`) from the repository root.


### PR DESCRIPTION
## Summary
- clarify Ruff check syntax in docs and DWC AGENTS guides
- document linting and testing workflow in development guide
- record documentation updates in changelog

## Testing
- `ruff check docs`
- `ruff check dwc`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c0b756d7dc832fb0be2d81b5912033