### PR TITLE
seedling: add codex task stubs for roadmap priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - :seedling: uv lockfile and bootstrap script for quick environment setup
 - :label: expand mapping rules for collector numbers and field note vocabulary
 - :dog: bootstrap script now runs linting and tests after syncing dependencies
+- :seedling: codex task stubs for multilingual OCR, custom schema mapping, and versioned exports
 
 ### Fixed
 - :bug: bootstrap script installs uv if missing
@@ -13,6 +14,7 @@
 ### Docs
 - :memo: outline testing and linting expectations in the development guide
 - 📝 clarify Ruff commands in AGENTS instructions and development guide
+- 📝 note upcoming multilingual OCR, mapping rules expansion, and versioned exports in docs
 
 ## [0.1.4] - 2025-09-10 (0.1.4)
 

--- a/config/rules/dwc_rules.toml
+++ b/config/rules/dwc_rules.toml
@@ -1,5 +1,6 @@
 # Mapping rules from raw OCR output to Darwin Core terms.
 # Use this file to declare regex or lookup substitutions.
+# TODO: expand with additional mappings (Issue TBD).
 
 # Field name aliases mapped to Darwin Core terms.
 [fields]

--- a/config/rules/vocab.toml
+++ b/config/rules/vocab.toml
@@ -1,5 +1,6 @@
 # Vocabulary normalisation tables.
 # Populate with mappings such as "Herbarium sheet" = "PreservedSpecimen".
+# TODO: extend controlled vocabularies (Issue TBD).
 
 [basisOfRecord]
 # Map common phrases to Darwin Core controlled terms

--- a/docs/export_and_reporting.md
+++ b/docs/export_and_reporting.md
@@ -73,3 +73,7 @@ PY
 Tag every export with a semantic version. The accompanying `manifest.json` makes
 it possible to reproduce the dataset by recording filters and the exact code
 commit.
+
+## Future work
+
+Versioned DwC-A bundles will embed manifests and semantic tags for reproducible releases (Issue TBD).

--- a/docs/mapping_and_vocabulary.md
+++ b/docs/mapping_and_vocabulary.md
@@ -33,6 +33,10 @@ The resulting `record.catalogNumber` is `"ABC123"`.
 The default rules already map common labels such as `collector number` to
 `recordNumber` via [`dwc_rules.toml`](../config/rules/dwc_rules.toml).
 
+## Future work
+
+Custom schema mapping via the `[dwc]` configuration section will allow external field definitions to be translated without modifying core code (Issue TBD). Additional mapping rules will be populated in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml` (Issue TBD).
+
 ## Vocabulary normalisation example
 
 Controlled terms such as `basisOfRecord` are harmonised via

--- a/docs/preprocessing_flows.md
+++ b/docs/preprocessing_flows.md
@@ -7,6 +7,8 @@ This document summarizes recommended preprocessing steps for each supported OCR 
 List the languages your project needs under `[ocr].langs` in the configuration. Tesseract models can be mapped explicitly via `[tesseract].model_paths`, allowing custom `.traineddata` locations. When no languages are provided, engines attempt automatic detection.
 PaddleOCR uses a single language code configured under `[paddleocr].lang`.
 
+Future work will integrate dedicated multilingual OCR models for non-English labels ([Issue #138](https://github.com/devvyn/aafc-herbarium-dwc-extraction-2025/issues/138)).
+
 ## Apple Vision
 
 | Step     | Purpose                                   | Recommended range |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,9 +7,9 @@ Run `python scripts/create_roadmap_issues.py --repo <owner>/<repo>` to open GitH
 **Critical features**
 - Integrate multilingual OCR models for non-English labels
 - Integrate GBIF taxonomy and locality verification into the QC pipeline
-- Configurable mapping from custom schemas via the [`[dwc]` section](configuration.md)
-- Versioned DwC-A export bundles with embedded manifest
-- Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml`
+- Configurable mapping from custom schemas via the [`[dwc]` section](configuration.md) (Issue TBD)
+- Versioned DwC-A export bundles with embedded manifest (Issue TBD)
+- Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml` (Issue TBD)
 
 Secondary tasks cover medium and low priority items detailed below.
 
@@ -21,8 +21,8 @@ Secondary tasks cover medium and low priority items detailed below.
 
 ## Mapping and vocabulary
 
-- Configurable mapping from custom schemas via the [`[dwc]` section](configuration.md) — **High**, Q2 2025
-- Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml` — **High**, Q2 2025
+ - Configurable mapping from custom schemas via the [`[dwc]` section](configuration.md) — **High**, Q2 2025 (Issue TBD)
+ - Populate mapping rules in `config/rules/dwc_rules.toml` and `config/rules/vocab.toml` — **High**, Q2 2025 (Issue TBD)
 - Support full schema parsing from official Darwin Core and ABCD XSDs — **Medium**, Q3 2025
 - Auto-generate Darwin Core term mappings from external XSD — **Low**, Q4 2025
 
@@ -39,7 +39,7 @@ Secondary tasks cover medium and low priority items detailed below.
 
 ## Export and reporting
 
-- Versioned DwC-A export bundles with embedded manifest — **High**, Q2 2025
+ - Versioned DwC-A export bundles with embedded manifest — **High**, Q2 2025 (Issue TBD)
 - Spreadsheet pivot table exports for data summaries — **Low**, Q4 2025
 
 ## Testing and documentation

--- a/dwc/archive.py
+++ b/dwc/archive.py
@@ -170,3 +170,14 @@ def create_archive(
             if file_path.exists():
                 zf.write(file_path, arcname=name)
     return archive_path
+
+
+def create_versioned_bundle(
+    output_dir: Path, version: str, filters: Dict[str, Any] | None = None
+) -> Path:
+    """Create a versioned DwC-A bundle with an embedded manifest.
+
+    Placeholder for forthcoming export enhancements. (Issue TBD)
+    """
+
+    raise NotImplementedError("Versioned DwC-A bundles are not yet implemented.")

--- a/dwc/mapper.py
+++ b/dwc/mapper.py
@@ -18,6 +18,16 @@ def configure_mappings(mapping: Dict[str, str]) -> None:
         _CUSTOM_MAPPINGS[raw.lower()] = term
 
 
+def map_custom_schema(record: Dict[str, Any], schema_mapping: Dict[str, str]) -> DwcRecord:
+    """Translate a record from a custom schema into Darwin Core terms.
+
+    This function will allow mapping arbitrary field names defined in the
+    configuration's `[dwc]` section. (Issue TBD)
+    """
+
+    raise NotImplementedError("Custom schema mapping is not yet implemented.")
+
+
 def map_ocr_to_dwc(ocr_output: Dict[str, Any], minimal_fields: Iterable[str] = ()) -> DwcRecord:
     """Translate OCR output into a :class:`DwcRecord`.
 

--- a/engines/multilingual.py
+++ b/engines/multilingual.py
@@ -1,0 +1,23 @@
+"""Multilingual OCR engine stubs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+from . import register_task
+
+
+def image_to_text(image: Path, langs: List[str]) -> Tuple[str, List[float]]:
+    """Extract text from an image using a multilingual OCR model.
+
+    This is a placeholder for future multilingual OCR integration.
+    See [Issue #138](https://github.com/devvyn/aafc-herbarium-dwc-extraction-2025/issues/138).
+    """
+
+    raise NotImplementedError("Multilingual OCR support is not yet implemented.")
+
+
+register_task("image_to_text", "multilingual", __name__, "image_to_text")
+
+__all__ = ["image_to_text"]


### PR DESCRIPTION
## Summary
- mark roadmap items with Issue TBD placeholders and dry-run issue creation script
- scaffold multilingual OCR engine, custom schema mapping, and versioned export bundle stubs
- document upcoming features and expand mapping/vocabulary rule notes

## Testing
- `AAFC_ISSUES=dummy python scripts/create_roadmap_issues.py --repo devvyn/aafc-herbarium-dwc-extraction-2025 --dry-run`
- `ruff check . --fix`
- `ruff check docs`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f51ecd4c832fa38f97d144b35071