### PR TITLE
Fix multilingual OCR stub registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - :bug: bootstrap script installs uv if missing
+- :bug: avoid auto-registering unimplemented multilingual OCR engine
 
 ### Docs
 - :memo: outline testing and linting expectations in the development guide

--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -83,7 +83,8 @@ def _discover_entry_points() -> None:
 
 
 # Import built-in engines so they register themselves on module import.
-for _mod in ("gpt", "vision_swift", "tesseract", "paddleocr", "multilingual"):
+# The multilingual stub is intentionally excluded until implemented.
+for _mod in ("gpt", "vision_swift", "tesseract", "paddleocr"):
     try:
         import_module(f"{__name__}.{_mod}")
     except Exception:  # pragma: no cover - optional deps may be missing


### PR DESCRIPTION
## Summary
- exclude unimplemented multilingual OCR engine from auto-registration
- record change in changelog

## Testing
- `ruff check . --fix`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', 'PIL', 'pyexcel', 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68c0fc9bc4f8832fa6dd68dce1ef5dd8