### PR TITLE
fix: rely solely on GITHUB_TOKEN for roadmap issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,4 @@
 ## Miscellaneous
 - No sensitive data is handled in this repository.
 - Default image format is JPEG unless otherwise specified.
+- Set `GITHUB_TOKEN` before running scripts that interact with the GitHub API.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,6 +8,7 @@
 - Examples should be reproducible via repository scripts; do not paste hand-edited outputs.
 - When features alter workflows or dependencies, refresh any affected usage or installation instructions (e.g., README.md and related docs).
 - Reviewers should verify these documentation updates during PR review.
+- Note any requirement to set `GITHUB_TOKEN` for scripts that call the GitHub API.
 
 ## Testing
 - Run `ruff check docs` and `pytest` from the repository root before committing documentation changes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 Upcoming features and priorities for the herbarium OCR to Darwin Core toolkit.
 
-Run `python scripts/create_roadmap_issues.py --repo <owner>/<repo>` to open GitHub issues for tasks marked with `(Issue TBD)`.
+Set `GITHUB_TOKEN` and run `python scripts/create_roadmap_issues.py --repo <owner>/<repo>` to open GitHub issues for tasks marked with `(Issue TBD)`.
 
 **Critical features**
 - Integrate multilingual OCR models for non-English labels

--- a/scripts/create_roadmap_issues.py
+++ b/scripts/create_roadmap_issues.py
@@ -114,9 +114,9 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="Do not call GitHub")
     args = parser.parse_args()
 
-    token = os.environ.get("AAFC_ISSUES") or os.environ.get("GITHUB_TOKEN")
+    token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        raise SystemExit("AAFC_ISSUES or GITHUB_TOKEN must be set")
+        raise SystemExit("GITHUB_TOKEN must be set")
 
     roadmap_path = Path(args.roadmap)
     text = roadmap_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- use only `GITHUB_TOKEN` in roadmap issue creation script
- document `GITHUB_TOKEN` requirement in AGENTS files and roadmap docs

## Testing
- `ruff check scripts docs`
- `pytest` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c1dcddc7cc832f93935d3566ff6f1a