### PR TITLE
feat: expand mapping and vocabulary rules

### DIFF
--- a/config/rules/dwc_rules.toml
+++ b/config/rules/dwc_rules.toml
@@ -1,6 +1,5 @@
 # Mapping rules from raw OCR output to Darwin Core terms.
 # Use this file to declare regex or lookup substitutions.
-# TODO: expand with additional mappings (Issue TBD).
 
 # Field name aliases mapped to Darwin Core terms.
 [fields]
@@ -24,3 +23,9 @@ locality = "locality"
 habitat = "habitat"
 
 "scientific name" = "scientificName"
+
+# Additional geographic fields
+lat = "decimalLatitude"
+latitude = "decimalLatitude"
+long = "decimalLongitude"
+longitude = "decimalLongitude"

--- a/config/rules/vocab.toml
+++ b/config/rules/vocab.toml
@@ -1,11 +1,11 @@
 # Vocabulary normalisation tables.
 # Populate with mappings such as "Herbarium sheet" = "PreservedSpecimen".
-# TODO: extend controlled vocabularies (Issue TBD).
 
 [basisOfRecord]
 # Map common phrases to Darwin Core controlled terms
 "herbarium sheet" = "PreservedSpecimen"
 "preserved specimen" = "PreservedSpecimen"
+"specimen voucher" = "PreservedSpecimen"
 "fossil" = "FossilSpecimen"
 "observation" = "HumanObservation"
 "field note" = "HumanObservation"
@@ -17,15 +17,20 @@ Isotype = "isotype"
 Paratype = "paratype"
 Lectotype = "lectotype"
 Neotype = "neotype"
+Syntype = "syntype"
 
 [habitat]
 # Normalise habitat descriptions
 bog = "bog"
 forest = "forest"
 wetland = "wetland"
+marsh = "wetland"
+grassland = "grassland"
 
 [coordinatePrecision]
 # Convert precision units to decimal degrees
 "1 m" = "0.00001"
 "10 m" = "0.0001"
 "100 m" = "0.001"
+"1 km" = "0.01"
+"10 km" = "0.1"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,6 +26,10 @@ model = "gpt-test"
 def test_normalize_vocab_rules() -> None:
     assert normalize_vocab("herbarium sheet", "basisOfRecord") == "PreservedSpecimen"
     assert normalize_vocab("Holotype", "typeStatus") == "holotype"
+    assert normalize_vocab("specimen voucher", "basisOfRecord") == "PreservedSpecimen"
+    assert normalize_vocab("Syntype", "typeStatus") == "syntype"
+    assert normalize_vocab("Marsh", "habitat") == "wetland"
+    assert normalize_vocab("1 km", "coordinatePrecision") == "0.01"
 
 
 def test_custom_mappings_from_config(tmp_path: Path) -> None:

--- a/tests/unit/test_qc.py
+++ b/tests/unit/test_qc.py
@@ -79,16 +79,20 @@ def test_map_ocr_to_dwc_rules() -> None:
             "collector number": "42",
             "date collected": "2025-09-01",
             "barcode": "ABC123",
-            "basisOfRecord": "herbarium sheet",
-            "typeStatus": "Holotype",
+            "lat": "51.5",
+            "long": "-0.1",
+            "basisOfRecord": "specimen voucher",
+            "typeStatus": "Syntype",
         }
     )
     assert record.recordedBy == "Jane Doe"
     assert record.eventDate == "2025-09-01"
     assert record.catalogNumber == "ABC123"
     assert record.recordNumber == "42"
+    assert record.decimalLatitude == "51.5"
+    assert record.decimalLongitude == "-0.1"
     assert record.basisOfRecord == "PreservedSpecimen"
-    assert record.typeStatus == "holotype"
+    assert record.typeStatus == "syntype"
 
 
 def test_normalize_vocab_field_note() -> None:


### PR DESCRIPTION
## Summary
- extend field mapping rules with latitude and longitude aliases
- broaden controlled vocabularies for specimens, types, habitats, and coordinate precision
- cover new rules with unit tests

## Testing
- `ruff check config tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1e45ff4e0832f9c17d592495fed36