### PR TITLE
Add custom schema mapping with config overrides

### DIFF
--- a/dwc/__init__.py
+++ b/dwc/__init__.py
@@ -1,5 +1,5 @@
 from .schema import DwcRecord, DWC_TERMS, configure_terms, resolve_term
-from .mapper import map_ocr_to_dwc, configure_mappings
+from .mapper import map_custom_schema, map_ocr_to_dwc, configure_mappings
 from .normalize import normalize_institution, normalize_vocab
 from .validators import (
     validate,
@@ -14,6 +14,7 @@ __all__ = [
     "configure_terms",
     "configure_mappings",
     "resolve_term",
+    "map_custom_schema",
     "map_ocr_to_dwc",
     "normalize_institution",
     "normalize_vocab",

--- a/tests/unit/test_mapper_custom.py
+++ b/tests/unit/test_mapper_custom.py
@@ -1,0 +1,11 @@
+from dwc import map_custom_schema
+
+
+def test_map_custom_schema_default() -> None:
+    record = map_custom_schema({"barcode": "ABC123"}, {})
+    assert record.catalogNumber == "ABC123"
+
+
+def test_map_custom_schema_override() -> None:
+    record = map_custom_schema({"barcode": "ABC123"}, {"barcode": "otherCatalogNumbers"})
+    assert record.otherCatalogNumbers == "ABC123"


### PR DESCRIPTION
## Summary
- implement configurable custom schema mapping for Darwin Core
- expose new mapping helper and cover with unit tests

## Testing
- `ruff check dwc tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1e7071dd0832fb9051782e5d758be