### PR TITLE
Add guidance for referencing issues in PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Summarize the changes and motivations in this PR -->
+
+## Testing
+- [ ] `ruff check . --fix`
+- [ ] `pytest`
+
+## Issue Links
+List any issues closed by this PR using the `Resolves #<issue-number>` syntax.
+
+- Resolves #
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - Start commit messages with a gitmoji (see [gitmoji.dev](https://gitmoji.dev)) followed by a short summary.
 - All updates to `CHANGELOG.md` must follow the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 - Use GitHub-style links for issues, commits, and pull requests (e.g. `[PR #42](https://github.com/your-org/your-repo/pull/42)`).
+- When a pull request is meant to close an issue, include a closing keyword such as `Resolves #<issue-number>` in the PR description.
 - Open pull requests only after all linting/tests pass.
 
 ## Issue Management

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
-Start by running `./bootstrap.sh` to install dependencies and run baseline checks. Follow the repository's guidelines in [AGENTS.md](AGENTS.md) and run `ruff check . --fix` and `pytest` before submitting changes.
+Start by running `./bootstrap.sh` to install dependencies and run baseline checks. Follow the repository's guidelines in [AGENTS.md](AGENTS.md) and run `ruff check . --fix` and `pytest` before submitting changes. When your pull request is meant to close an issue, include a closing keyword such as `Resolves #<issue-number>` in the PR description.
 
 Review [docs/development.md](docs/development.md) for development conventions and consult the [roadmap](docs/roadmap.md) for open tasks and priorities.


### PR DESCRIPTION
## Summary
- document using `Resolves #<issue-number>` in PR descriptions when closing issues
- prompt contributors to list issues in PR template

## Testing
- `ruff check . --fix`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c1f6c82c7c832fa2146429d0745776