### PR TITLE
Add batch resizing helper and configurable image extension support

### DIFF
--- a/docs/preprocessing_flows.md
+++ b/docs/preprocessing_flows.md
@@ -2,6 +2,10 @@
 
 This document summarizes recommended preprocessing steps for each supported OCR engine. The steps correspond to functions in `preprocess` and can be composed via the `pipeline` list in the configuration file's `[preprocess]` section.
 
+## Batch resizing helper
+
+Use `python scripts/batch_resize.py --input input/ --output resized/` to downscale large sheets before running the main pipeline. The helper mirrors the input directory, limits the longest edge to the configured `max_dim_px`, and copies images that are already below the threshold. Provide `--max-dim` to override the value detected from `config.default.toml` or `--dry-run` to preview the changes.
+
 ## Multilingual setup
 
 List the languages your project needs under `[ocr].langs` in the configuration. The CLI now accepts ISO 639-1 (two-letter) and ISO 639-2 (three-letter) codes and normalizes them so Tesseract receives the expected model identifiers while PaddleOCR and the multilingual engine get two-letter hints. Tesseract models can be mapped explicitly via `[tesseract].model_paths`, allowing custom `.traineddata` locations. When no languages are provided, engines attempt automatic detection.

--- a/io_utils/read.py
+++ b/io_utils/read.py
@@ -1,14 +1,20 @@
 from pathlib import Path
-from typing import Iterator
+from typing import Iterable, Iterator
 import hashlib
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
 
 
-def iter_images(input_dir: Path) -> Iterator[Path]:
+def _normalize_extensions(extensions: Iterable[str]) -> set[str]:
+    return {ext.lower() if ext.startswith(".") else f".{ext.lower()}" for ext in extensions}
+
+
+def iter_images(input_dir: Path, extensions: Iterable[str] | None = None) -> Iterator[Path]:
     """Yield image paths from a directory recursively."""
+
+    allowed = _normalize_extensions(extensions) if extensions is not None else IMAGE_EXTENSIONS
     for path in sorted(input_dir.rglob("*")):
-        if path.suffix.lower() in IMAGE_EXTENSIONS:
+        if path.suffix.lower() in allowed:
             yield path
 
 

--- a/scripts/batch_resize.py
+++ b/scripts/batch_resize.py
@@ -1,0 +1,144 @@
+"""Batch resize helper for preprocessing herbarium images.
+
+The script limits the longest edge for every image in an input directory to
+reduce OCR latency.  It can operate in-place or mirror the resized files to an
+output directory so the original images remain untouched.  By default the
+maximum dimension is read from the repository's ``config.default.toml`` and can
+be overridden on the command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from importlib import resources
+from pathlib import Path
+import sys
+from typing import Dict, Optional
+
+from PIL import Image, ImageOps
+
+from io_utils.read import iter_images
+from preprocess import resize
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def _deep_update(base: Dict[str, object], override: Dict[str, object]) -> Dict[str, object]:
+    """Recursively merge ``override`` into ``base`` and return ``base``."""
+
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_update(base[key], value)  # type: ignore[arg-type]
+        else:
+            base[key] = value
+    return base
+
+
+def _load_preprocess_config(path: Optional[Path]) -> Dict[str, object]:
+    """Return the merged configuration for the ``[preprocess]`` section."""
+
+    cfg_path = resources.files("config").joinpath("config.default.toml")
+    with cfg_path.open("rb") as handle:
+        config = tomllib.load(handle)
+    if path:
+        with path.open("rb") as handle:
+            user_cfg = tomllib.load(handle)
+        _deep_update(config, user_cfg)
+    return config.get("preprocess", {})  # type: ignore[return-value]
+
+
+def _destination_path(source: Path, input_dir: Path, output_dir: Optional[Path]) -> Path:
+    if output_dir is None:
+        return source
+    return output_dir / source.relative_to(input_dir)
+
+
+def _save_image(img: Image.Image, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    save_kwargs = {"format": img.format} if img.format else {}
+    img.save(destination, **save_kwargs)
+
+
+def resize_directory(
+    input_dir: Path,
+    output_dir: Optional[Path],
+    max_dim: int,
+    dry_run: bool = False,
+) -> Dict[str, int]:
+    """Resize every image in ``input_dir`` and return a summary map."""
+
+    if max_dim <= 0:
+        raise ValueError("max_dim must be greater than zero")
+
+    summary = {"total": 0, "resized": 0, "skipped": 0, "copied": 0}
+    images = list(iter_images(input_dir))
+    summary["total"] = len(images)
+
+    for image_path in images:
+        destination = _destination_path(image_path, input_dir, output_dir)
+
+        with Image.open(image_path) as img:
+            oriented = ImageOps.exif_transpose(img)
+            longest_edge = max(oriented.size)
+
+            if longest_edge <= max_dim:
+                if output_dir is not None:
+                    if not dry_run:
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(image_path, destination)
+                    summary["copied"] += 1
+                else:
+                    summary["skipped"] += 1
+                continue
+
+            if dry_run:
+                summary["resized"] += 1
+                continue
+
+            resized = resize(oriented, max_dim)
+            _save_image(resized, destination)
+            summary["resized"] += 1
+
+    return summary
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Batch resize herbarium images")
+    parser.add_argument("--input", type=Path, required=True, help="Directory containing source images")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional directory to mirror resized files; defaults to in-place updates",
+    )
+    parser.add_argument("--config", type=Path, help="Optional configuration file merged over config.default.toml")
+    parser.add_argument("--max-dim", type=int, help="Maximum length of the longest edge in pixels")
+    parser.add_argument("--dry-run", action="store_true", help="Show actions without writing files")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    pre_cfg = _load_preprocess_config(args.config)
+    default_max = int(pre_cfg.get("max_dim_px", 3072))
+    max_dim = args.max_dim or default_max
+
+    output_dir = args.output
+    if output_dir and not args.dry_run:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = resize_directory(args.input, output_dir, max_dim, dry_run=args.dry_run)
+
+    print(
+        f"Processed {summary['total']} images: "
+        f"{summary['resized']} resized, {summary['copied']} copied, {summary['skipped']} skipped"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/integration/test_batch_resize.py
+++ b/tests/integration/test_batch_resize.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from PIL import Image
+
+from scripts.batch_resize import resize_directory
+
+
+def _make_image(path: Path, size: tuple[int, int]) -> None:
+    Image.new("RGB", size, color="white").save(path)
+
+
+def test_resize_directory_resizes_and_copies(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+
+    large = input_dir / "large.jpg"
+    small = input_dir / "small.png"
+    nested_dir = input_dir / "nested"
+    nested_dir.mkdir()
+    nested_large = nested_dir / "nested_large.jpg"
+
+    _make_image(large, (5000, 3000))
+    _make_image(small, (800, 600))
+    _make_image(nested_large, (4500, 4500))
+
+    summary = resize_directory(input_dir, output_dir, max_dim=3000, dry_run=False)
+
+    assert summary == {"total": 3, "resized": 2, "skipped": 0, "copied": 1}
+
+    with Image.open(output_dir / "large.jpg") as img:
+        assert max(img.size) == 3000
+        assert img.size[0] == 3000
+    with Image.open(output_dir / "nested" / "nested_large.jpg") as img:
+        assert max(img.size) == 3000
+    with Image.open(output_dir / "small.png") as img:
+        assert img.size == (800, 600)
+
+
+def test_resize_directory_dry_run(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    large = input_dir / "large.jpg"
+    _make_image(large, (4001, 3000))
+
+    summary = resize_directory(input_dir, None, max_dim=3500, dry_run=True)
+
+    assert summary == {"total": 1, "resized": 1, "skipped": 0, "copied": 0}
+    assert list(input_dir.glob("*")) == [large]

--- a/tests/unit/test_read.py
+++ b/tests/unit/test_read.py
@@ -36,3 +36,15 @@ def test_compute_sha256_hash(tmp_path: Path) -> None:
     file_path.write_bytes(data)
     expected = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
     assert compute_sha256(file_path) == expected
+
+
+def test_iter_images_custom_extensions(tmp_path: Path) -> None:
+    (tmp_path / "sheet.tif").write_text("a")
+    (tmp_path / "slide.TIFF").write_text("b")
+    (tmp_path / "photo.jpg").write_text("c")
+
+    images = list(iter_images(tmp_path, extensions={"tif", ".tiff"}))
+
+    assert images == sorted(
+        [tmp_path / "sheet.tif", tmp_path / "slide.TIFF"], key=lambda p: str(p)
+    )


### PR DESCRIPTION
## Summary
- add a `scripts/batch_resize.py` helper that mirrors or resizes herbarium images before OCR runs, with coverage tests and documentation
- document the new resizing helper in the preprocessing guide
- allow `io_utils.read.iter_images` to accept custom extension lists and add TIFF-focused tests

## Testing
- ruff check .
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce33a0da68832f8bc2c93eb622ca62